### PR TITLE
Step2 - 연관 관계 매핑

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -62,20 +62,8 @@ public class Answer extends BaseTimeEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public User getWriter() {
         return writer;
-    }
-
-    public void setWriter(User writer) {
-        this.writer = writer;
-    }
-
-    public void setQuestion(Question question) {
-        this.question = question;
     }
 
     public Question getQuestion() {
@@ -86,7 +74,7 @@ public class Answer extends BaseTimeEntity {
         return contents;
     }
 
-    public void setContents(String contents) {
+    public void changeContents(String contents) {
         this.contents = contents;
     }
 
@@ -94,7 +82,7 @@ public class Answer extends BaseTimeEntity {
         return deleted;
     }
 
-    public void setDeleted(boolean deleted) {
+    public void changeDeleted(boolean deleted) {
         this.deleted = deleted;
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -13,7 +13,9 @@ public class Answer extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
@@ -43,13 +45,13 @@ public class Answer extends BaseTimeEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
+        this.writer = writer;
         this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -64,12 +66,16 @@ public class Answer extends BaseTimeEntity {
         this.id = id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public void setWriter(User writer) {
+        this.writer = writer;
+    }
+
+    public void setQuestion(Question question) {
+        this.question = question;
     }
 
     public Question getQuestion() {
@@ -96,8 +102,6 @@ public class Answer extends BaseTimeEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-//                ", questionId=" + questionId +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -15,7 +15,9 @@ public class Answer extends BaseTimeEntity {
 
     private Long writerId;
 
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
 
     @Lob
     private String contents;
@@ -42,7 +44,7 @@ public class Answer extends BaseTimeEntity {
         }
 
         this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.question = question;
         this.contents = contents;
     }
 
@@ -51,7 +53,7 @@ public class Answer extends BaseTimeEntity {
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
@@ -70,12 +72,8 @@ public class Answer extends BaseTimeEntity {
         this.writerId = writerId;
     }
 
-    public Long getQuestionId() {
-        return questionId;
-    }
-
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
+    public Question getQuestion() {
+        return question;
     }
 
     public String getContents() {
@@ -99,7 +97,7 @@ public class Answer extends BaseTimeEntity {
         return "Answer{" +
                 "id=" + id +
                 ", writerId=" + writerId +
-                ", questionId=" + questionId +
+//                ", questionId=" + questionId +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/BaseTimeEntity.java
+++ b/src/main/java/qna/domain/BaseTimeEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -56,14 +56,6 @@ public class DeleteHistory {
         return contentId;
     }
 
-    public void setContentType(ContentType contentType) {
-        this.contentType = contentType;
-    }
-
-    public void setContentId(Long contentId) {
-        this.contentId = contentId;
-    }
-
     public User getDeletedBy() {
         return deletedBy;
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -19,7 +18,10 @@ public class DeleteHistory {
     private ContentType contentType;
 
     private Long contentId;
-    private Long deletedById;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "deletedById", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
 
     @CreatedDate
     private LocalDateTime createDate;
@@ -27,26 +29,10 @@ public class DeleteHistory {
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DeleteHistory that = (DeleteHistory) o;
-        return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        this.deletedBy = deletedBy;
     }
 
     @Override
@@ -55,7 +41,6 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
                 '}';
     }
 
@@ -71,10 +56,6 @@ public class DeleteHistory {
         return contentId;
     }
 
-    public Long getDeletedById() {
-        return deletedById;
-    }
-
     public void setContentType(ContentType contentType) {
         this.contentType = contentType;
     }
@@ -83,8 +64,8 @@ public class DeleteHistory {
         this.contentId = contentId;
     }
 
-    public void setDeletedById(Long deletedById) {
-        this.deletedById = deletedById;
+    public User getDeletedBy() {
+        return deletedBy;
     }
 
     public LocalDateTime getCreateDate() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -51,23 +51,15 @@ public class Question extends BaseTimeEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     public String getContents() {
         return contents;
     }
 
-    public void setContents(String contents) {
+    public void changeContents(String contents) {
         this.contents = contents;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -15,7 +15,9 @@ public class Question extends BaseTimeEntity {
     @Lob
     private String contents;
 
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
 
     @Column(nullable = false)
     private boolean deleted;
@@ -33,12 +35,12 @@ public class Question extends BaseTimeEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -69,12 +71,8 @@ public class Question extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public boolean isDeleted() {
@@ -91,7 +89,6 @@ public class Question extends BaseTimeEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -87,7 +87,7 @@ public class User extends BaseTimeEntity {
         return userId;
     }
 
-    public void setUserId(String userId) {
+    public void changeUserId(String userId) {
         this.userId = userId;
     }
 
@@ -95,24 +95,12 @@ public class User extends BaseTimeEntity {
         return password;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public String getEmail() {
         return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     @Override

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -8,7 +8,6 @@ import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.domain.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,10 +47,10 @@ public class QnAService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -49,7 +49,7 @@ public class QnAService {
         question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter()));
         for (Answer answer : answers) {
-            answer.setDeleted(true);
+            answer.changeDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter()));
         }
         deleteHistoryService.saveAll(deleteHistories);

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -51,7 +51,7 @@ public class QnAService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -81,13 +81,15 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     @Test
     @DisplayName("Question 엔티티 @ManyToOne 관계 매핑 테스트")
     void manyToOneQuestionTest() {
-        assertThat(answer.getQuestion().getId()).isNotNull();
+        assertThat(savedAnswer.getQuestion()).isNotNull();
+        assertThat(savedAnswer.getQuestion().getId()).isNotNull();
     }
 
     @Test
     @DisplayName("User 엔티티 @ManyToOne 관계 매핑 테스트")
     void manyToOneUserTest() {
-        assertThat(answer.getWriter().getId()).isNotNull();
+        assertThat(savedAnswer.getWriter()).isNotNull();
+        assertThat(savedAnswer.getWriter().getId()).isNotNull();
     }
 
     @AfterEach

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -73,7 +73,7 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     @Test
     @DisplayName("update 시 updateAt 이 자동으로 변경된다.")
     void dateAutoModifyTest() {
-        savedAnswer.setContents("update date?");
+        savedAnswer.changeContents("update date?");
         answers.flush();
 
         assertThat(savedAnswer.getUpdateAt()).isNotNull();

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -16,17 +16,16 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     @Autowired
     private AnswerRepository answers;
 
-    @Autowired
-    private QuestionRepository questions;
-
     Answer answer;
     Answer savedAnswer;
 
     @BeforeEach
     void setUp() {
-        answer = new Answer(UserTest.JAVAJIGI, new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI), "Answers Contents1");
+        answer = new Answer(
+                new User("javajigi", "password", "name", "javajigi@slipp.net"),
+                new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI)
+                , "Answers Contents1");
         savedAnswer = answers.save(answer);
-//        savedAnswer.toQuestion(questions.save(Q1));
     }
 
     @Test
@@ -55,7 +54,7 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
                 () -> assertThat(savedAnswer.getId()).isNotNull(),
                 () -> assertThat(savedAnswer.getContents()).isEqualTo(answer.getContents()),
                 () -> assertThat(savedAnswer.getQuestion()).isSameAs(answer.getQuestion()),
-                () -> assertThat(savedAnswer.getWriterId()).isEqualTo(answer.getWriterId()),
+                () -> assertThat(savedAnswer.getWriter()).isEqualTo(answer.getWriter()),
                 () -> assertThat(savedAnswer.isDeleted()).isEqualTo(answer.isDeleted())
         );
     }
@@ -80,9 +79,15 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     }
 
     @Test
-    @DisplayName("@ManyToOne 관계 매핑 테스트")
-    void manyToOneTest(){
+    @DisplayName("Question 엔티티 @ManyToOne 관계 매핑 테스트")
+    void manyToOneQuestionTest() {
         assertThat(answer.getQuestion().getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("User 엔티티 @ManyToOne 관계 매핑 테스트")
+    void manyToOneUserTest() {
+        assertThat(answer.getWriter().getId()).isNotNull();
     }
 
     @AfterEach

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -14,15 +14,19 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class AnswerRepositoryTest extends BaseDataJpaTest {
 
     @Autowired
-    private AnswerRepository repository;
+    private AnswerRepository answers;
+
+    @Autowired
+    private QuestionRepository questions;
 
     Answer answer;
     Answer savedAnswer;
 
     @BeforeEach
     void setUp() {
-        answer = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-        savedAnswer = repository.save(answer);
+        answer = new Answer(UserTest.JAVAJIGI, new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI), "Answers Contents1");
+        savedAnswer = answers.save(answer);
+//        savedAnswer.toQuestion(questions.save(Q1));
     }
 
     @Test
@@ -34,8 +38,8 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     @Test
     @DisplayName("조회한 데이터와 같은 id 값을 가진 엔티티는 동일해야 한다")
     void entityRetrieveTest() {
-        List<Answer> findAnswers = repository.findByQuestionIdAndDeletedFalse(answer.getQuestionId());
-        Answer findAnswer = repository.findById(savedAnswer.getId()).get();
+        List<Answer> findAnswers = answers.findAll();
+        Answer findAnswer = answers.findById(savedAnswer.getId()).get();
 
         assertAll(
                 () -> assertThat(findAnswers.get(0)).isSameAs(savedAnswer),
@@ -50,7 +54,7 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
         assertAll(
                 () -> assertThat(savedAnswer.getId()).isNotNull(),
                 () -> assertThat(savedAnswer.getContents()).isEqualTo(answer.getContents()),
-                () -> assertThat(savedAnswer.getQuestionId()).isEqualTo(answer.getQuestionId()),
+                () -> assertThat(savedAnswer.getQuestion()).isSameAs(answer.getQuestion()),
                 () -> assertThat(savedAnswer.getWriterId()).isEqualTo(answer.getWriterId()),
                 () -> assertThat(savedAnswer.isDeleted()).isEqualTo(answer.isDeleted())
         );
@@ -70,13 +74,19 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     @DisplayName("update 시 updateAt 이 자동으로 변경된다.")
     void dateAutoModifyTest() {
         savedAnswer.setContents("update date?");
-        repository.flush();
+        answers.flush();
 
         assertThat(savedAnswer.getUpdateAt()).isNotNull();
     }
 
+    @Test
+    @DisplayName("@ManyToOne 관계 매핑 테스트")
+    void manyToOneTest(){
+        assertThat(answer.getQuestion().getId()).isNotNull();
+    }
+
     @AfterEach
     void endUp() {
-        repository.deleteAll();
+        answers.deleteAll();
     }
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -23,7 +23,8 @@ class AnswerRepositoryTest extends BaseDataJpaTest {
     void setUp() {
         answer = new Answer(
                 new User("javajigi", "password", "name", "javajigi@slipp.net"),
-                new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI)
+                new Question("title1", "contents1")
+                        .writeBy(new User("sanjigi", "password", "name", "sanjigi@slipp.net"))
                 , "Answers Contents1");
         savedAnswer = answers.save(answer);
     }

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -19,7 +19,7 @@ class DeleteHistoryRepositoryTest extends BaseDataJpaTest {
 
     @BeforeEach
     void setUp() {
-        deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, 1L);
+        deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, new User("javajigi", "password", "name", "javajigi@slipp.net"));
         savedDeleteHistory = repository.save(deleteHistory);
     }
 
@@ -44,9 +44,15 @@ class DeleteHistoryRepositoryTest extends BaseDataJpaTest {
                 () -> assertThat(savedDeleteHistory.getId()).isNotNull(),
                 () -> assertThat(savedDeleteHistory.getContentType()).isEqualTo(deleteHistory.getContentType()),
                 () -> assertThat(savedDeleteHistory.getContentId()).isEqualTo(deleteHistory.getContentId()),
-                () -> assertThat(savedDeleteHistory.getDeletedById()).isEqualTo(deleteHistory.getDeletedById())
+                () -> assertThat(savedDeleteHistory.getDeletedBy()).isSameAs(deleteHistory.getDeletedBy())
         );
+    }
 
+    @Test
+    @DisplayName("User 엔티티 @ManyToOne 관계 매핑 테스트")
+    void manyToOneUserTest() {
+        assertThat(savedDeleteHistory.getDeletedBy()).isNotNull();
+        assertThat(savedDeleteHistory.getDeletedBy().getId()).isNotNull();
     }
 
     @Test

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -69,7 +69,7 @@ class QuestionRepositoryTest extends BaseDataJpaTest {
     @Test
     @DisplayName("update 시 updateAt 이 자동으로 변경된다.")
     void dateAutoModifyTest() {
-        savedQuestion.setContents("update date?");
+        savedQuestion.changeContents("update date?");
         repository.flush();
 
         assertThat(savedQuestion.getUpdateAt()).isNotNull();

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -21,7 +20,8 @@ class QuestionRepositoryTest extends BaseDataJpaTest {
 
     @BeforeEach
     void setUp() {
-        question = new Question(Q1.getTitle(), Q1.getContents());
+        question = new Question(Q1.getTitle(), Q1.getContents())
+                .writeBy(new User("javajigi", "password", "name", "javajigi@slipp.net"));
         savedQuestion = repository.save(question);
     }
 
@@ -51,8 +51,8 @@ class QuestionRepositoryTest extends BaseDataJpaTest {
                 () -> assertThat(savedQuestion.getId()).isNotNull(),
                 () -> assertThat(savedQuestion.getContents()).isEqualTo(question.getContents()),
                 () -> assertThat(savedQuestion.getTitle()).isEqualTo(question.getTitle()),
-                () -> assertThat(savedQuestion.getWriterId()).isEqualTo(question.getWriterId()),
-                () -> assertThat(savedQuestion.isDeleted()).isEqualTo(question.isDeleted())
+                () -> assertThat(savedQuestion.isDeleted()).isEqualTo(question.isDeleted()),
+                () -> assertThat(savedQuestion.getWriter()).isSameAs(question.getWriter())
         );
     }
 
@@ -73,6 +73,13 @@ class QuestionRepositoryTest extends BaseDataJpaTest {
         repository.flush();
 
         assertThat(savedQuestion.getUpdateAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("User 엔티티 @ManyToOne 관계 매핑 테스트")
+    void manyToOneUserTest() {
+        assertThat(savedQuestion.getWriter()).isNotNull();
+        assertThat(savedQuestion.getWriter().getId()).isNotNull();
     }
 
     @AfterEach

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -67,7 +67,7 @@ class UserRepositoryTest extends BaseDataJpaTest {
     @Test
     @DisplayName("update 시 updateAt 이 자동으로 변경된다.")
     void dateAutoModifyTest() {
-        savedUser.setUserId("update date?");
+        savedUser.changeUserId("update date?");
         repository.flush();
 
         assertThat(savedUser.getUpdateAt()).isNotNull();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import qna.CannotDeleteException;
 import qna.domain.*;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -89,8 +88,8 @@ class QnAServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -90,7 +90,7 @@ class QnAServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:~/test;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
+spring.datasource.username=sa
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.output.ansi.enabled=always
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=trace


### PR DESCRIPTION
개발 편의성을 위해 cascade persist 옵션을 추가했는데 권장되는 형태인지 아닌지 궁금합니다.
setter 를 일단 남겨 뒀는데 없애는게 더 낫겠죠??
oneToMany 보다는 ManyToOne 을 더 권장하는 거 같아 이것만 사용했는데 양방향도 하는게 좋을까요?
이번 미션은 사소한 걸 놓쳐 테스트가 계속 실패해 조금 애를 먹었네요 ㅎㅎ
간만에 JPA 엔티티 설정하면서 공부한 했던 것들 많이 복기도 하고 재밌게 했습니다.

이번에도 날카로운 리뷰 부탁드립니다