### PR TITLE
feat:  학습 1단계 - 엔티티 매핑

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,16 +1,34 @@
 package qna.domain;
 
+import net.bytebuddy.dynamic.loading.InjectionClassLoader;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
+import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
-public class Answer {
+@Entity
+@Table(name = "answer")
+public class Answer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "writer_id")
     private Long writerId;
+
+    @Column(name = "question_id")
     private Long questionId;
+
+    @Lob
     private String contents;
+
+    @Column(nullable = false)
     private boolean deleted = false;
+
+    protected Answer() {
+    }
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);

--- a/src/main/java/qna/domain/BaseEntity.java
+++ b/src/main/java/qna/domain/BaseEntity.java
@@ -1,0 +1,15 @@
+package qna.domain;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public class BaseEntity {
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime  createdAt = LocalDateTime.now();
+
+    @Column(name = "update_at")
+    private LocalDateTime  updateAt;
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,14 +1,31 @@
 package qna.domain;
 
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@Entity
+@Table(name = "delete_history")
 public class DeleteHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "content_type")
+    @Enumerated(value = EnumType.STRING)
     private ContentType contentType;
+
+    @Column(name = "content_id")
     private Long contentId;
+
+    @Column(name = "deleted_by_id")
     private Long deletedById;
-    private LocalDateTime createDate = LocalDateTime.now();
+
+    @Column(name = "create_date")
+    private LocalDateTime createDate;
+
+    protected DeleteHistory() {
+    }
 
     public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
         this.contentType = contentType;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,28 @@
 package qna.domain;
 
-public class Question {
+import javax.persistence.*;
+
+@Entity
+@Table(name = "question")
+public class Question extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, length = 100)
     private String title;
+
+    @Lob
     private String contents;
+
+    @Column(name = "writer_id")
     private Long writerId;
+
+    @Column(nullable = false)
     private boolean deleted = false;
+
+    protected Question() {
+    }
 
     public Question(String title, String contents) {
         this(null, title, contents);

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -2,15 +2,28 @@ package qna.domain;
 
 import qna.UnAuthorizedException;
 
+import javax.persistence.*;
 import java.util.Objects;
 
-public class User {
+@Entity
+@Table(name = "user")
+public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "user_id", nullable = false, length = 20)
     private String userId;
+
+    @Column(nullable = false, length = 20)
     private String password;
+
+    @Column(nullable = false, length = 20)
     private String name;
+
+    @Column(length = 50)
     private String email;
 
     private User() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
-spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:tcp://localhost/~/test
 spring.datasource.username=sa
 spring.h2.console.enabled=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import javax.persistence.EntityManager;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +16,10 @@ public class AnswerTest {
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
 
     @Autowired
-    AnswerRepository answers;
+    private AnswerRepository answers;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
     void save() {
@@ -40,6 +44,8 @@ public class AnswerTest {
     void update() {
         Answer expected = answers.save(AnswerTest.A1);
         expected.setDeleted(true);
+        entityManager.flush();
+        entityManager.clear();
         Optional<Answer> actual = answers.findById(expected.getId());
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get().isDeleted()).isTrue();
@@ -49,6 +55,8 @@ public class AnswerTest {
     void delete() {
         Answer expected = answers.save(AnswerTest.A1);
         answers.delete(expected);
+        entityManager.flush();
+        entityManager.clear();
         Optional<Answer> actual = answers.findById(expected.getId());
         assertThat(actual.isPresent()).isFalse();
     }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,55 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @Autowired
+    AnswerRepository answers;
+
+    @Test
+    void save() {
+        Answer expected = AnswerTest.A1;
+        Answer actual = answers.save(expected);
+        assertAll(
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getWriterId()).isEqualTo(expected.getWriterId())
+        );
+    }
+
+    @Test
+    void findById() {
+        Answer expected = answers.save(AnswerTest.A2);
+        Optional<Answer> actual = answers.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().getId()).isEqualTo(expected.getId());
+        assertThat(actual.get() == expected).isTrue();
+    }
+
+    @Test
+    void update() {
+        Answer expected = answers.save(AnswerTest.A1);
+        expected.setDeleted(true);
+        Optional<Answer> actual = answers.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete() {
+        Answer expected = answers.save(AnswerTest.A1);
+        answers.delete(expected);
+        Optional<Answer> actual = answers.findById(expected.getId());
+        assertThat(actual.isPresent()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,55 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+    
+    @Autowired
+    QuestionRepository questions;
+
+    @Test
+    void save() {
+        Question expected = QuestionTest.Q1;
+        Question actual = questions.save(expected);
+        assertAll(
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getWriterId()).isEqualTo(expected.getWriterId())
+        );
+    }
+
+    @Test
+    void findById() {
+        Question expected = questions.save(QuestionTest.Q2);
+        Optional<Question> actual = questions.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().getId()).isEqualTo(expected.getId());
+        assertThat(actual.get() == expected).isTrue();
+    }
+
+    @Test
+    void update() {
+        Question expected = questions.save(QuestionTest.Q1);
+        expected.setDeleted(true);
+        Optional<Question> actual = questions.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().isDeleted()).isTrue();
+    }
+
+    @Test
+    void delete() {
+        Question expected = questions.save(QuestionTest.Q2);
+        questions.delete(expected);
+        Optional<Question> actual = questions.findById(expected.getId());
+        assertThat(actual.isPresent()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,9 +1,11 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import javax.persistence.EntityManager;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,9 +17,13 @@ public class QuestionTest {
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
     
     @Autowired
-    QuestionRepository questions;
+    private QuestionRepository questions;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
+    @DisplayName("질문 테이블 정상 저장 테스트")
     void save() {
         Question expected = QuestionTest.Q1;
         Question actual = questions.save(expected);
@@ -28,6 +34,7 @@ public class QuestionTest {
     }
 
     @Test
+    @DisplayName("질문 테이블 아이디 정상 조회 테스트")
     void findById() {
         Question expected = questions.save(QuestionTest.Q2);
         Optional<Question> actual = questions.findById(expected.getId());
@@ -37,18 +44,24 @@ public class QuestionTest {
     }
 
     @Test
+    @DisplayName("질문 테이블 정상 수정 테스트")
     void update() {
         Question expected = questions.save(QuestionTest.Q1);
         expected.setDeleted(true);
+        entityManager.flush();
+        entityManager.clear();
         Optional<Question> actual = questions.findById(expected.getId());
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get().isDeleted()).isTrue();
     }
 
     @Test
+    @DisplayName("질문 테이블 정상 삭제 테스트")
     void delete() {
         Question expected = questions.save(QuestionTest.Q2);
         questions.delete(expected);
+        entityManager.flush();
+        entityManager.clear();
         Optional<Question> actual = questions.findById(expected.getId());
         assertThat(actual.isPresent()).isFalse();
     }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -1,6 +1,56 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
 public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+    
+    @Autowired
+    UserRepository users;
+
+    @Test
+    void save() {
+        User expected = UserTest.JAVAJIGI;
+        User actual = users.save(expected);
+        assertAll(
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getEmail()).isEqualTo(expected.getEmail())
+        );
+    }
+
+    @Test
+    void findById() {
+        User expected = users.save(UserTest.SANJIGI);
+        Optional<User> actual = users.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().getId()).isEqualTo(expected.getId());
+        assertThat(actual.get() == expected).isTrue();
+    }
+
+    @Test
+    void update() {
+        String name = "mwkwon";
+        User expected = users.save(UserTest.JAVAJIGI);
+        expected.setName(name);
+        Optional<User> actual = users.findById(expected.getId());
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get().getName()).isEqualTo(name);
+    }
+
+    @Test
+    void delete() {
+        User expected = users.save(UserTest.SANJIGI);
+        users.delete(expected);
+        Optional<User> actual = users.findById(expected.getId());
+        assertThat(actual.isPresent()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -1,9 +1,11 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import javax.persistence.EntityManager;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,13 +13,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 public class UserTest {
-    public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-    public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+    public static final User JAVAJIGI = new User("javajigi", "password", "name", "javajigi@slipp.net");
+    public static final User SANJIGI = new User("sanjigi", "password", "name", "sanjigi@slipp.net");
     
     @Autowired
-    UserRepository users;
+    private UserRepository users;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
+    @DisplayName("회원 정보 테이블 정상 저장 테스트")
     void save() {
         User expected = UserTest.JAVAJIGI;
         User actual = users.save(expected);
@@ -28,6 +34,7 @@ public class UserTest {
     }
 
     @Test
+    @DisplayName("유저 아이디 기준 조회 테스트")
     void findById() {
         User expected = users.save(UserTest.SANJIGI);
         Optional<User> actual = users.findById(expected.getId());
@@ -37,19 +44,25 @@ public class UserTest {
     }
 
     @Test
+    @DisplayName("회원 정보 테이블 정상 수정 테스트")
     void update() {
         String name = "mwkwon";
         User expected = users.save(UserTest.JAVAJIGI);
         expected.setName(name);
+        entityManager.flush();
+        entityManager.clear();
         Optional<User> actual = users.findById(expected.getId());
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get().getName()).isEqualTo(name);
     }
 
     @Test
+    @DisplayName("회원 정보 테이블 정상 삭제 테스트")
     void delete() {
         User expected = users.save(UserTest.SANJIGI);
         users.delete(expected);
+        entityManager.flush();
+        entityManager.clear();
         Optional<User> actual = users.findById(expected.getId());
         assertThat(actual.isPresent()).isFalse();
     }


### PR DESCRIPTION
학습 내용을 바탕으로 엔티티 매핑 정보 기입
관련 crud 테스트 코드 작성

안녕하세요~!!!!
신랄하고 뼈때리는 리뷰 부탁 드립니다..~^^

궁금한 사항이 있는데 
jpa 테스트 코드 작성 시  업데이트나 delete 쿼리가 실제로 나가지않고 1차 캐시에서만 처리되는 것으로 보이는데
실제 쿼리를 확인할려면 어떻게 해야할지 궁금합니다.
flush(), clear()를 처리하면 실제 쿼리를 볼 수 있을거 같은데
clear() method가 없더라구요...ㅠㅠ

감사합니다.