### PR TITLE
Step3 - 질문 삭제하기 리팩터링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import com.sun.istack.NotNull;
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -93,6 +94,12 @@ public class Answer extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public void checkAnswerOwner(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -6,6 +6,7 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 
@@ -100,6 +101,10 @@ public class Answer extends BaseEntity {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
+    }
+
+    public DeleteHistory registerDeleteHistory() {
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -31,6 +31,10 @@ public class Answers {
         return deleteHistories;
     }
 
+    public List<Answer> getAnswers() {
+        return new ArrayList<>(answers);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,46 @@
+package qna.domain;
+
+import qna.CannotDeleteException;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Embeddable
+public class Answers {
+
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers = new ArrayList<>();
+
+    protected Answers() {
+    }
+
+    public void add(Answer answer) {
+        answers.add(answer);
+    }
+
+    public List<DeleteHistory> deleteAll(User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : answers) {
+            answer.checkAnswerOwner(loginUser);
+            answer.setDeleted(true);
+            deleteHistories.add(answer.registerDeleteHistory());
+        }
+        return deleteHistories;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Answers answers1 = (Answers) o;
+        return Objects.equals(answers, answers1.answers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(answers);
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -21,8 +21,8 @@ public class Answers {
         answers.add(answer);
     }
 
-    public List<DeleteHistory> deleteAll(User loginUser) throws CannotDeleteException {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+    public DeleteHistories deleteAll(User loginUser) throws CannotDeleteException {
+        DeleteHistories deleteHistories = new DeleteHistories();
         for (Answer answer : answers) {
             answer.checkAnswerOwner(loginUser);
             answer.setDeleted(true);

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,19 @@
+package qna.domain;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DeleteHistories {
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = Collections.unmodifiableList(deleteHistories);
+    }
+
+    public List<DeleteHistory> merge(List<DeleteHistory> otherHistories) {
+        return Stream.concat(deleteHistories.stream(), otherHistories.stream())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,8 +13,17 @@ public class DeleteHistories {
         this.deleteHistories = Collections.unmodifiableList(deleteHistories);
     }
 
-    public List<DeleteHistory> merge(List<DeleteHistory> otherHistories) {
-        return Stream.concat(deleteHistories.stream(), otherHistories.stream())
+    public DeleteHistories(DeleteHistory... deleteHistories) {
+        this.deleteHistories = Arrays.stream(deleteHistories)
                 .collect(Collectors.toList());
+    }
+
+    public List<DeleteHistory> merge(DeleteHistories other) {
+        return Stream.concat(deleteHistories.stream(), other.deleteHistories.stream())
+                .collect(Collectors.toList());
+    }
+
+    public void add(DeleteHistory deleteHistory) {
+        deleteHistories.add(deleteHistory);
     }
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,9 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
+
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -93,8 +96,26 @@ public class Question extends BaseEntity {
         return new ArrayList<>(answers);
     }
 
-    public List<DeleteHistory> delete(User loginUser) {
-        return new ArrayList<>();
+    public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        List<Answer> answers = getAnswers();
+        for (Answer answer : answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+        }
+
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        setDeleted(true);
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        for (Answer answer : answers) {
+            answer.setDeleted(true);
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        }
+        return new ArrayList<>(deleteHistories);
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -93,6 +93,10 @@ public class Question extends BaseEntity {
         return new ArrayList<>(answers);
     }
 
+    public List<DeleteHistory> delete(User loginUser) {
+        return new ArrayList<>();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -4,7 +4,6 @@ import qna.CannotDeleteException;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -44,16 +43,14 @@ public class Question extends BaseEntity {
     }
 
     public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
-        DeleteHistories deleteHistories = new DeleteHistories(deleteQuestion(loginUser));
+        DeleteHistories deleteHistories = deleteQuestion(loginUser);
         return deleteHistories.merge(answers.deleteAll(loginUser));
     }
 
-    private List<DeleteHistory> deleteQuestion(User loginUser) throws CannotDeleteException {
+    private DeleteHistories deleteQuestion(User loginUser) throws CannotDeleteException {
         checkQuestionOwner(loginUser);
         setDeleted(true);
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
-        return deleteHistories;
+        return new DeleteHistories(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
     }
 
     private void checkQuestionOwner(User loginUser) throws CannotDeleteException {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -97,24 +97,28 @@ public class Question extends BaseEntity {
     }
 
     public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteQuestion(loginUser, deleteHistories);
-        deleteAnswers(loginUser, deleteHistories);
-        return new ArrayList<>(deleteHistories);
+        List<DeleteHistory> questionHistories = deleteQuestion(loginUser);
+        List<DeleteHistory> answersHistories = deleteAnswers(loginUser);
+        questionHistories.addAll(answersHistories);
+        return new ArrayList<>(questionHistories);
     }
 
-    private void deleteQuestion(User loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
+    private List<DeleteHistory> deleteQuestion(User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
         checkQuestionOwner(loginUser);
         setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        return deleteHistories;
     }
 
-    private void deleteAnswers(User loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
+    private List<DeleteHistory> deleteAnswers(User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : answers) {
             answer.checkAnswerOwner(loginUser);
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
+        return deleteHistories;
     }
 
     private void checkQuestionOwner(User loginUser) throws CannotDeleteException {

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -35,6 +35,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
         if (!question.isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
@@ -46,7 +47,7 @@ public class QnAService {
             }
         }
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        //List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -36,24 +36,6 @@ public class QnAService {
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
         List<DeleteHistory> deleteHistories = question.delete(loginUser);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        //List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -64,5 +65,14 @@ public class AnswerTest {
 
         assertThatThrownBy(() -> new Answer(1L, UserTest.SANJIGI, question, "답변내용"))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("answer 질문 작성자 아닐 경우 예외발생 테스트")
+    void checkOwner() throws CannotDeleteException {
+        answer.checkAnswerOwner(UserTest.JAVAJIGI);
+
+        assertThatThrownBy(() -> answer.checkAnswerOwner(UserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
     }
 }

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,65 @@
+package qna.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AnswersTest {
+
+    private Question question;
+    private Answer answer1;
+    private Answer answer2;
+    private Answers answers;
+
+    @BeforeEach
+    void setUp() {
+        question = new Question(1L, "질문1", "질문내용");
+        answer1 = new Answer(UserTest.JAVAJIGI, question, "답변내용1");
+        answer2 = new Answer(UserTest.JAVAJIGI, question, "답변내용2");
+        answers = new Answers();
+
+        answers.add(answer1);
+        answers.add(answer2);
+    }
+
+    @Test
+    @DisplayName("Answers 클래스 내의 컬렉션에 질문 요소를 추가하여 저장 테스트")
+    void add() {
+        List<Answer> resultAnswers = this.answers.getAnswers();
+        assertAll(
+                () -> assertThat(resultAnswers).hasSize(2),
+                () -> assertThat(resultAnswers.get(0).isDeleted()).isFalse(),
+                () -> assertThat(resultAnswers.get(1).isDeleted()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("질문들 전부 삭제 테스트")
+    void deleteAll() throws CannotDeleteException {
+        answers.deleteAll(UserTest.JAVAJIGI);
+
+        List<Answer> resultAnswers = this.answers.getAnswers();
+        assertAll(
+                () -> assertThat(resultAnswers.get(0).isDeleted()).isTrue(),
+                () -> assertThat(resultAnswers.get(1).isDeleted()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("질문들 전부 삭제시 작성자가 다른 답변이 있을경우 실패한다.(예외발생)")
+    void deleteAll_fail() {
+        Answer answer3 = new Answer(UserTest.SANJIGI, question, "답변내용3");
+        answers.add(answer3);
+
+        assertThatThrownBy(() -> answers.deleteAll(UserTest.JAVAJIGI))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+}

--- a/src/test/java/qna/domain/DeleteHistoriesTest.java
+++ b/src/test/java/qna/domain/DeleteHistoriesTest.java
@@ -1,0 +1,41 @@
+package qna.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.time.LocalDateTime.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static qna.domain.ContentType.ANSWER;
+import static qna.domain.ContentType.QUESTION;
+import static qna.domain.UserTest.JAVAJIGI;
+import static qna.domain.UserTest.SANJIGI;
+
+class DeleteHistoriesTest {
+
+    private List<DeleteHistory> questionDeletes;
+    private List<DeleteHistory> answerDeletes;
+    private DeleteHistories deleteHistories;
+
+    @Test
+    @DisplayName("deleteHistoriy 들을 합친 컬렉션을 리턴한다.")
+    void merge() {
+        questionDeletes = Collections.singletonList(new DeleteHistory(QUESTION, 1L, JAVAJIGI, now()));
+        answerDeletes = Collections.singletonList(new DeleteHistory(ANSWER, 1L, SANJIGI, now()));
+
+        deleteHistories = new DeleteHistories(questionDeletes);
+
+        List<DeleteHistory> mergedResults = deleteHistories.merge(answerDeletes);
+
+        assertAll(
+                () -> assertThat(mergedResults).hasSize(2),
+                () -> assertThat(mergedResults.get(0).getContentType()).isEqualTo(QUESTION),
+                () -> assertThat(mergedResults.get(0).getDeleteUser()).isEqualTo(JAVAJIGI),
+                () -> assertThat(mergedResults.get(1).getContentType()).isEqualTo(ANSWER),
+                () -> assertThat(mergedResults.get(1).getDeleteUser()).isEqualTo(SANJIGI)
+        );
+    }
+}

--- a/src/test/java/qna/domain/DeleteHistoriesTest.java
+++ b/src/test/java/qna/domain/DeleteHistoriesTest.java
@@ -3,7 +3,6 @@ package qna.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static java.time.LocalDateTime.now;
@@ -16,17 +15,17 @@ import static qna.domain.UserTest.SANJIGI;
 
 class DeleteHistoriesTest {
 
-    private List<DeleteHistory> questionDeletes;
-    private List<DeleteHistory> answerDeletes;
+    private DeleteHistory questionDelete;
+    private DeleteHistories answerDeletes;
     private DeleteHistories deleteHistories;
 
     @Test
     @DisplayName("deleteHistoriy 들을 합친 컬렉션을 리턴한다.")
     void merge() {
-        questionDeletes = Collections.singletonList(new DeleteHistory(QUESTION, 1L, JAVAJIGI, now()));
-        answerDeletes = Collections.singletonList(new DeleteHistory(ANSWER, 1L, SANJIGI, now()));
+        questionDelete = new DeleteHistory(QUESTION, 1L, JAVAJIGI, now());
+        answerDeletes = new DeleteHistories(new DeleteHistory(ANSWER, 1L, SANJIGI, now()));
 
-        deleteHistories = new DeleteHistories(questionDeletes);
+        deleteHistories = new DeleteHistories(questionDelete);
 
         List<DeleteHistory> mergedResults = deleteHistories.merge(answerDeletes);
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -51,7 +51,7 @@ public class QuestionTest {
 
     @Test
     @DisplayName("Question delete 테스트 - 정상 삭제일 경우")
-    void delete() {
+    void delete() throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = question.delete(UserTest.JAVAJIGI);
 
         assertAll(

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -5,9 +5,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import qna.CannotDeleteException;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
@@ -43,5 +47,24 @@ public class QuestionTest {
         question.updateContents(changedContents);
 
         assertThat(question.getContents()).isEqualTo(changedContents);
+    }
+
+    @Test
+    @DisplayName("Question delete 테스트 - 정상 삭제일 경우")
+    void delete() {
+        List<DeleteHistory> deleteHistories = question.delete(UserTest.JAVAJIGI);
+
+        assertAll(
+                () -> assertThat(question.isDeleted()),
+                () -> assertThat(deleteHistories).isNotEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("Question delete 테스트 - 질문 작성자와 제거하려는 유저가 다를 때 예외 발생")
+    void delete_throw_exception() {
+        assertThatThrownBy(() -> question.delete(UserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("질문을 삭제할 권한이 없습니다.");
     }
 }


### PR DESCRIPTION
안녕하세요 리뷰어님-!

이번 단계는 getter를 없애고
각 변수를 저장하고 있는 도메인 객체 내에서
처리가 되도록 하는걸 중점으로 리팩토링 해보았습니다.

나름 메소드별 1개의 역할만 하게끔 처리한 거 같긴 한데
한가지 걸리는 건
List<DeleteHistory> deleteHistories = new ArrayList<>();
이 부분과 add로 DeleteHistory 하는 부분이 
따로 떼고 싶게끔 보이는데요..

delete 로직에서 삭제시 예외가 발생하면 기록되면 안되는 것이
로직상 맞는 거 같아서 delete 로직과 같이 둘 수 밖에 없는게 
저 부분을 따로 떼기가 힘들게 하네요 😭

이 부분은 그냥 두는 게 좋을지 
아니면 다른 방향이 있을지 조언 부탁드려도 될까요?

오늘도 가감없는 리뷰 부탁드립니다.
항상 감사드립니다-!