### PR TITLE
3단계 - 질문 삭제하기 리펙터링 리뷰요청드립니다.

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -67,7 +67,7 @@ public class Answer extends BaseEntity {
 	}
 
 	public void toQuestion(Question question) {
-		if(Objects.nonNull(this.question)) {
+		if (Objects.nonNull(this.question)) {
 			this.question.getAnswers().remove(this);
 		}
 		this.question = question;
@@ -99,10 +99,14 @@ public class Answer extends BaseEntity {
 	}
 
 	public DeleteHistory delete(User loginUser) throws CannotDeleteException {
+		validateDelete(loginUser);
+		this.setDeleted(true);
+		return new DeleteHistory(ContentType.ANSWER, this.id, this.writer, LocalDateTime.now());
+	}
+
+	private void validateDelete(User loginUser) throws CannotDeleteException {
 		if (!this.isOwner(loginUser)) {
 			throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
 		}
-		this.setDeleted(true);
-		return new DeleteHistory(ContentType.ANSWER, this.id, this.writer, LocalDateTime.now());
 	}
 }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,37 @@
+package qna.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+import qna.CannotDeleteException;
+
+@Embeddable
+public class Answers {
+
+	@OneToMany(mappedBy = "question")
+	List<Answer> answers = new ArrayList<>();
+
+	public void add(Answer answer) {
+		this.answers.add(answer);
+	}
+
+	public void remove(Answer answer) {
+		this.answers.remove(answer);
+	}
+
+	public int getSize() {
+		return this.answers.size();
+	}
+
+	public List<DeleteHistory> deleteAll(User loginUser) throws CannotDeleteException {
+		List<DeleteHistory> answerDeleteHistories = new ArrayList<>();
+		for (Answer answer : this.answers) {
+			answerDeleteHistories.add(answer.delete(loginUser));
+		}
+		return answerDeleteHistories;
+	}
+
+}

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -1,7 +1,5 @@
 package qna.service;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -10,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.domain.AnswerRepository;
-import qna.domain.DeleteHistory;
 import qna.domain.Question;
 import qna.domain.QuestionRepository;
 import qna.domain.User;
@@ -39,7 +36,6 @@ public class QnAService {
 	@Transactional
 	public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
 		Question question = findQuestionById(questionId);
-		List<DeleteHistory> deleteHistories = question.delete(loginUser);
-		deleteHistoryService.saveAll(deleteHistories);
+		deleteHistoryService.saveAll(question.delete(loginUser));
 	}
 }

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -1,7 +1,5 @@
 package qna.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -11,9 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.Answer;
 import qna.domain.AnswerRepository;
-import qna.domain.ContentType;
 import qna.domain.DeleteHistory;
 import qna.domain.Question;
 import qna.domain.QuestionRepository;
@@ -43,26 +39,7 @@ public class QnAService {
 	@Transactional
 	public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
 		Question question = findQuestionById(questionId);
-		if (!question.isOwner(loginUser)) {
-			throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-		}
-
-		List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-		for (Answer answer : answers) {
-			if (!answer.isOwner(loginUser)) {
-				throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-			}
-		}
-
-		List<DeleteHistory> deleteHistories = new ArrayList<>();
-		question.setDeleted(true);
-		deleteHistories.add(
-			new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-		for (Answer answer : answers) {
-			answer.setDeleted(true);
-			deleteHistories.add(
-				new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-		}
+		List<DeleteHistory> deleteHistories = question.delete(loginUser);
 		deleteHistoryService.saveAll(deleteHistories);
 	}
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import qna.CannotDeleteException;
+
 @DataJpaTest
 public class AnswerRepositoryTest {
 
@@ -87,6 +89,17 @@ public class AnswerRepositoryTest {
 		answers.delete(saved);
 		answers.flush();
 		assertThat(answers.findByIdAndDeletedFalse(savedId).isPresent()).isFalse();
+	}
+
+
+	@Test
+	@DisplayName("Answer Sort 삭제 테스트")
+	void deleteSort() throws CannotDeleteException {
+		Answer answer = new Answer(writer, question, "내용");
+		Answer saved = answers.save(answer);
+		answer.delete(writer);
+		answers.flush();
+		assertThat(answer.isDeleted()).isTrue();
 	}
 
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -99,7 +99,7 @@ public class AnswerRepositoryTest {
 		Answer saved = answers.save(answer);
 		answer.delete(writer);
 		answers.flush();
-		assertThat(answer.isDeleted()).isTrue();
+		assertThat(saved.isDeleted()).isTrue();
 	}
 
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -87,10 +87,8 @@ public class QuestionRepositoryTest {
 		List<DeleteHistory> deleteHistories = saved.delete(writer);
 		questions.flush();
 		Question findQuestion = questions.findById(saved.getId()).get();
-		assertThat(findQuestion.getAnswers()).hasSize(2);
+		assertThat(findQuestion.getAnswers().getSize()).isEqualTo(2);
 		assertThat(findQuestion.isDeleted()).isTrue();
-		for (Answer answerInQuestion : findQuestion.getAnswers()) {
-			assertThat(answerInQuestion.isDeleted()).isTrue();
-		}
+		assertThat(deleteHistories).hasSize(3);
 	}
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -52,7 +52,6 @@ class QnAServiceTest {
 	@Test
 	public void delete_성공() throws Exception {
 		when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-		when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
 		assertThat(question.isDeleted()).isFalse();
 		qnAService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -72,7 +71,6 @@ class QnAServiceTest {
 	@Test
 	public void delete_성공_질문자_답변자_같음() throws Exception {
 		when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-		when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
 		qnAService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -87,8 +85,6 @@ class QnAServiceTest {
 		question.addAnswer(answer2);
 
 		when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-		when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(
-			Arrays.asList(answer, answer2));
 
 		assertThatThrownBy(() -> qnAService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
 			.isInstanceOf(CannotDeleteException.class);


### PR DESCRIPTION
안녕하세요 곽태민입니다.
3단계 질문 삭제하기 리펙터링은 클린코드와 JPA 경험을 동시에 할 수 있는 경험이라 좋은 것 같습니다.

질문이 있는데 해당 코드에서

```java
	public List<DeleteHistory> deleteAll(User loginUser) throws CannotDeleteException {
		List<DeleteHistory> answerDeleteHistories = new ArrayList<>();
		for (Answer answer : this.answers) {
			answerDeleteHistories.add(answer.delete(loginUser));
		}
		return answerDeleteHistories;
	}
```
해당 부분을 stream()으로 구현하려 했으나,  answer.delete(loginUser)에 
throw가 있어 stream안의 try catch문이 강요되는데 혹시 좋은 방법이 있는지 궁금합니다.
리뷰 잘 부탁드립니다. 감사합니다.

