### PR TITLE
Step3 - JPA (질문 삭제하기 리팩터링) 리뷰 요청드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,80 @@ alter table question
         foreign key (writer_id)
             references user (id)
 ```
+
+---
+
+## 3단계 - 질문 삭제하기 리팩터링
+
+###기능 요구 사항
+QnA 서비스를 만들어가면서 JPA로 실제 도메인 모델을 어떻게 구성하고 객체와 테이블을 어떻게 매핑해야 하는지 알아본다.
+
+- 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
+- 로그인 사용자와 질문한 사람이 같은 경우 삭제할 수 있다.
+- 답변이 없는 경우 삭제가 가능하다.
+- 질문자와 답변 글의 모든 답변자 같은 경우 삭제가 가능하다.
+- 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경한다.
+- 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.
+- 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.
+
+###프로그래밍 요구 사항
+- `qna.service.QnaService`의 `deleteQuestion()`는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메서드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
+- 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드를 분리해 단위 테스트 가능한 코드에 대해 단위 테스트를 구현한다.
+- 리팩터링을 완료한 후에도 `src/test/java` 디렉터리의 `qna.service.QnaServiceTest`의 모든 테스트가 통과해야 한다.
+```java
+@Transactional
+public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
+    Question question = findQuestionById(questionId);
+    if (!question.isOwner(loginUser)) {
+        throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+    }
+
+    List<Answer> answers = question.getAnswers();
+    for (Answer answer : answers) {
+        if (!answer.isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+    }
+
+    List<DeleteHistory> deleteHistories = new ArrayList<>();
+    question.setDeleted(true);
+    deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+    for (Answer answer : answers) {
+        answer.setDeleted(true);
+        deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+    }
+    deleteHistoryService.saveAll(deleteHistories);
+}
+```
+
+* 자바 코드 컨벤션을 지키면서 프로그래밍한다.
+    * 기본적으로 Google Java Style Guide을 원칙으로 한다.
+    * 단, 들여쓰기는 '2 spaces'가 아닌 '4 spaces'로 한다.
+* indent(인덴트, 들여쓰기) depth를 2를 넘지 않도록 구현한다. 1까지만 허용한다.
+    * 예를 들어 while문 안에 if문이 있으면 들여쓰기는 2이다.
+    * 힌트: indent(인덴트, 들여쓰기) depth를 줄이는 좋은 방법은 함수(또는 메서드)를 분리하면 된다.
+* 3항 연산자를 쓰지 않는다.
+* else 예약어를 쓰지 않는다.
+    * else 예약어를 쓰지 말라고 하니 switch/case로 구현하는 경우가 있는데 switch/case도 허용하지 않는다.
+    * 힌트: if문에서 값을 반환하는 방식으로 구현하면 else 예약어를 사용하지 않아도 된다.
+* 모든 기능을 TDD로 구현해 단위 테스트가 존재해야 한다. 단, UI(System.out, System.in) 로직은 제외
+    * 핵심 로직을 구현하는 코드와 UI를 담당하는 로직을 구분한다.
+    * UI 로직을 InputView, ResultView와 같은 클래스를 추가해 분리한다.
+* 함수(또는 메서드)의 길이가 10라인을 넘어가지 않도록 구현한다.
+    * 함수(또는 메소드)가 한 가지 일만 하도록 최대한 작게 만들어라.
+* 배열 대신 컬렉션을 사용한다.
+* 모든 원시 값과 문자열을 포장한다
+* 줄여 쓰지 않는다(축약 금지).
+* 일급 컬렉션을 쓴다.
+* 모든 엔티티를 작게 유지한다.
+* 3개 이상의 인스턴스 변수를 가진 클래스를 쓰지 않는다.
+
+###힌트
+테스트하기 쉬운 부분과 테스트하기 어려운 부분을 분리해 테스트 가능한 부분만 단위 테스트한다.
+
+<img src="https://user-images.githubusercontent.com/67728580/120141423-6df8f280-c217-11eb-8dee-55987fb2a43e.png" width="100%" height="100%" />
+
+<img src="https://user-images.githubusercontent.com/67728580/120141453-7f41ff00-c217-11eb-8fc1-c765534bafd8.png" width="100%" height="100%" />
+
+<img src="https://user-images.githubusercontent.com/67728580/120141493-8d901b00-c217-11eb-8590-3cf7a11dccfe.png" width="100%" height="100%" />
+

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -88,10 +88,6 @@ public class Answer extends BaseEntity {
         return deleted;
     }
 
-    public void setDeleted(boolean deleted) {
-        this.deleted = deleted;
-    }
-
     public Question getQuestion() {
         return question;
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -72,18 +72,6 @@ public class Answer extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -21,7 +21,7 @@ import qna.exception.UnAuthorizedException;
 @Entity
 public class Answer extends BaseEntity {
 
-    public static final String NO_PERMISSION_TO_DELETE_ANSWER = "답변을 삭제할 권한이 없습니다.";
+    private static final String NO_PERMISSION_TO_DELETE_ANSWER = "답변을 삭제할 권한이 없습니다.";
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -72,7 +72,7 @@ public class Answer extends BaseEntity {
         return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
-    public boolean isOwner(User writer) {
+    private boolean isOwner(User writer) {
         return this.writer.equals(writer);
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -13,12 +14,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import qna.exception.CannotDeleteException;
 import qna.exception.NotFoundException;
 import qna.exception.UnAuthorizedException;
 
 @Entity
 public class Answer extends BaseEntity {
 
+    public static final String NO_PERMISSION_TO_DELETE_ANSWER = "답변을 삭제할 권한이 없습니다.";
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -58,6 +61,15 @@ public class Answer extends BaseEntity {
 
     protected Answer() {
 
+    }
+
+    public DeleteHistory delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException(NO_PERMISSION_TO_DELETE_ANSWER);
+        }
+        deleted = true;
+
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
     public boolean isOwner(User writer) {
@@ -108,11 +120,11 @@ public class Answer extends BaseEntity {
     @Override
     public String toString() {
         return "Answer{" +
-                "id=" + id +
-                ", writer.id=" + writer.getId() +
-                ", question.id=" + question.getId() +
-                ", contents='" + contents + '\'' +
-                ", deleted=" + deleted +
-                '}';
+            "id=" + id +
+            ", writer.id=" + writer.getId() +
+            ", question.id=" + question.getId() +
+            ", contents='" + contents + '\'' +
+            ", deleted=" + deleted +
+            '}';
     }
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -63,7 +63,7 @@ public class Answer extends BaseEntity {
 
     }
 
-    public DeleteHistory delete(User loginUser) throws CannotDeleteException {
+    public DeleteHistory delete(User loginUser) {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException(NO_PERMISSION_TO_DELETE_ANSWER);
         }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,27 @@
+package qna.domain;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import qna.exception.CannotDeleteException;
+
+public class Answers {
+
+    public static final String CANNOT_DELETE_SOMEONE_ELSE_ANSWER = "다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.";
+    private final List<Answer> answers;
+
+    public Answers(Answer... answers) {
+        this.answers = Arrays.asList(answers);
+    }
+
+    public DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
+        try {
+            List<DeleteHistory> deleteHistories = answers.stream()
+                .map(answer -> answer.delete(loginUser))
+                .collect(Collectors.toList());
+            return new DeleteHistories(deleteHistories);
+        } catch (CannotDeleteException e) {
+            throw new CannotDeleteException(CANNOT_DELETE_SOMEONE_ELSE_ANSWER);
+        }
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -14,6 +14,10 @@ public class Answers {
         this.answers = Arrays.asList(answers);
     }
 
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
     public DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
         try {
             List<DeleteHistory> deleteHistories = answers.stream()
@@ -23,5 +27,11 @@ public class Answers {
         } catch (CannotDeleteException e) {
             throw new CannotDeleteException(CANNOT_DELETE_SOMEONE_ELSE_ANSWER);
         }
+    }
+
+    public List<Answer> undeletedAnswers() {
+        return answers.stream()
+            .filter(answer -> !answer.isDeleted())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -18,7 +18,7 @@ public class Answers {
         this.answers = answers;
     }
 
-    public DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
+    public DeleteHistories deleteAnswers(User loginUser) {
         try {
             return answers.stream()
                 .map(answer -> answer.delete(loginUser))

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -20,10 +20,9 @@ public class Answers {
 
     public DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
         try {
-            List<DeleteHistory> deleteHistories = answers.stream()
+            return answers.stream()
                 .map(answer -> answer.delete(loginUser))
-                .collect(Collectors.toList());
-            return new DeleteHistories(deleteHistories);
+                .collect(Collectors.collectingAndThen(Collectors.toList(), DeleteHistories::new));
         } catch (CannotDeleteException e) {
             throw new CannotDeleteException(CANNOT_DELETE_SOMEONE_ELSE_ANSWER);
         }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,17 +1,29 @@
 package qna.domain;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
 import qna.exception.CannotDeleteException;
 
+@Embeddable
 public class Answers {
 
     public static final String CANNOT_DELETE_SOMEONE_ELSE_ANSWER = "다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.";
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "question", cascade = CascadeType.PERSIST)
     private final List<Answer> answers;
 
+    public Answers() {
+        answers = new ArrayList<>();
+    }
+
     public Answers(Answer... answers) {
-        this.answers = Arrays.asList(answers);
+        this.answers = new ArrayList<>(Arrays.asList(answers));
     }
 
     public Answers(List<Answer> answers) {
@@ -32,5 +44,9 @@ public class Answers {
         return answers.stream()
             .filter(answer -> !answer.isDeleted())
             .collect(Collectors.toList());
+    }
+
+    public void add(Answer answer) {
+        answers.add(answer);
     }
 }

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -9,7 +8,7 @@ public class DeleteHistories {
     private final List<DeleteHistory> deleteHistories;
 
     public DeleteHistories(DeleteHistory... deleteHistories) {
-        this.deleteHistories = new ArrayList<>(Arrays.asList(deleteHistories));
+        this(Arrays.asList(deleteHistories));
     }
 
     public DeleteHistories(List<DeleteHistory> deleteHistories) {

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,16 @@
+package qna.domain;
+
+import java.util.List;
+
+public class DeleteHistories {
+
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -8,7 +9,7 @@ public class DeleteHistories {
     private final List<DeleteHistory> deleteHistories;
 
     public DeleteHistories(DeleteHistory... deleteHistories) {
-        this(Arrays.asList(deleteHistories));
+        this(new ArrayList<>(Arrays.asList(deleteHistories)));
     }
 
     public DeleteHistories(List<DeleteHistory> deleteHistories) {

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,13 +1,23 @@
 package qna.domain;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class DeleteHistories {
 
     private final List<DeleteHistory> deleteHistories;
 
+    public DeleteHistories(DeleteHistory... deleteHistories) {
+        this.deleteHistories = new ArrayList<>(Arrays.asList(deleteHistories));
+    }
+
     public DeleteHistories(List<DeleteHistory> deleteHistories) {
         this.deleteHistories = deleteHistories;
+    }
+
+    public void addAll(DeleteHistories otherHistories) {
+        this.deleteHistories.addAll(otherHistories.deleteHistories);
     }
 
     public List<DeleteHistory> getDeleteHistories() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -74,7 +74,7 @@ public class Question extends BaseEntity {
 
     }
 
-    public DeleteHistories delete(User loginUser) throws CannotDeleteException {
+    public DeleteHistories delete(User loginUser) {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException(NO_PERMISSION_TO_DELETE_QUESTION);
         }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -82,10 +82,6 @@ public class Question extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
     }
@@ -96,10 +92,6 @@ public class Question extends BaseEntity {
 
     public String getContents() {
         return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,10 @@
 package qna.domain;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
@@ -14,7 +13,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import qna.exception.CannotDeleteException;
 
@@ -39,8 +37,8 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "question", cascade = CascadeType.PERSIST)
-    private List<Answer> answers = new ArrayList<>();
+    @Embedded
+    private Answers answers = new Answers();
 
     public Question(String title, String contents) {
         this(null, title, contents);
@@ -120,7 +118,7 @@ public class Question extends BaseEntity {
     }
 
     public Answers getAnswers() {
-        return new Answers(answers);
+        return answers;
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -56,6 +56,13 @@ public class Question extends BaseEntity {
         this(null, title, contents, writer);
     }
 
+    public Question(String title, String contents, User writer, boolean deleted) {
+        this.title = title;
+        this.contents = contents;
+        this.writer = writer;
+        this.deleted = deleted;
+    }
+
     public Question(Long id, String title, String contents, User writer) {
         this.id = id;
         this.title = title;
@@ -100,21 +107,12 @@ public class Question extends BaseEntity {
         return title;
     }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
     public String getContents() {
         return contents;
     }
 
     public boolean isDeleted() {
         return deleted;
-    }
-
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
     }
 
     public User getWriter() {
@@ -153,4 +151,8 @@ public class Question extends BaseEntity {
             '}';
     }
 
+    public void update(Question question) {
+        this.title = question.getTitle();
+        this.contents = question.getContents();
+    }
 }

--- a/src/main/java/qna/exception/CannotDeleteException.java
+++ b/src/main/java/qna/exception/CannotDeleteException.java
@@ -1,6 +1,6 @@
 package qna.exception;
 
-public class CannotDeleteException extends Exception {
+public class CannotDeleteException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public CannotDeleteException(String message) {

--- a/src/main/java/qna/service/DeleteHistoryService.java
+++ b/src/main/java/qna/service/DeleteHistoryService.java
@@ -3,6 +3,7 @@ package qna.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import qna.domain.DeleteHistories;
 import qna.domain.DeleteHistory;
 import qna.repository.DeleteHistoryRepository;
 
@@ -17,8 +18,8 @@ public class DeleteHistoryService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveAll(List<DeleteHistory> deleteHistories) {
-        deleteHistoryRepository.saveAll(deleteHistories);
+    public void saveAll(DeleteHistories deleteHistories) {
+        deleteHistoryRepository.saveAll(deleteHistories.getDeleteHistories());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -1,19 +1,14 @@
 package qna.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import qna.exception.CannotDeleteException;
-import qna.exception.NotFoundException;
-import qna.domain.Answer;
-import qna.domain.ContentType;
-import qna.domain.DeleteHistory;
+import qna.domain.DeleteHistories;
 import qna.domain.Question;
 import qna.domain.User;
+import qna.exception.CannotDeleteException;
+import qna.exception.NotFoundException;
 import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
 
@@ -41,24 +36,7 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        DeleteHistories deleteHistories = question.delete(loginUser);
+        deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import qna.domain.DeleteHistories;
 import qna.domain.Question;
 import qna.domain.User;
-import qna.exception.CannotDeleteException;
 import qna.exception.NotFoundException;
 import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
@@ -34,7 +33,7 @@ public class QnaService {
     }
 
     @Transactional
-    public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
+    public void deleteQuestion(User loginUser, Long questionId) {
         Question question = findQuestionById(questionId);
         DeleteHistories deleteHistories = question.delete(loginUser);
         deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -28,7 +28,6 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) {
         Question question = findQuestionById(questionId);
-        DeleteHistories deleteHistories = question.delete(loginUser);
-        deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());
+        deleteHistoryService.saveAll(question.delete(loginUser));
     }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -1,28 +1,21 @@
 package qna.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import qna.domain.DeleteHistories;
 import qna.domain.Question;
 import qna.domain.User;
 import qna.exception.NotFoundException;
-import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
 
 @Service
 public class QnaService {
 
-    private static final Logger log = LoggerFactory.getLogger(QnaService.class);
-
     private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
     private DeleteHistoryService deleteHistoryService;
 
-    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
+    public QnaService(QuestionRepository questionRepository, DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
-        this.answerRepository = answerRepository;
         this.deleteHistoryService = deleteHistoryService;
     }
 

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,41 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import qna.exception.CannotDeleteException;
+
 public class AnswerTest {
+
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @Test
+    void 답변자가_맞는지_확인() {
+        User answerer = UserTest.JAVAJIGI;
+        assertThat(A1.isOwner(answerer)).isTrue();
+    }
+
+    @Test
+    void 답변삭제시_질문자와_다를경우_예외발생() {
+        User loginUser = UserTest.HOONHEE;
+        assertThatThrownBy(() -> A1.delete(loginUser))
+            .isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    void 삭제시_삭제상태가_변경되는지_확인() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+        A1.delete(loginUser);
+        assertThat(A1.isDeleted()).isTrue();
+    }
+
+    @Test
+    void 삭제시_삭제이력을_반환하는지_확인() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+        DeleteHistory deleteHistory = A1.delete(loginUser);
+        assertThat(deleteHistory).isNotNull();
+    }
+
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -12,12 +12,6 @@ public class AnswerTest {
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
 
     @Test
-    void 답변자가_맞는지_확인() {
-        User answerer = UserTest.JAVAJIGI;
-        assertThat(A1.isOwner(answerer)).isTrue();
-    }
-
-    @Test
     void 답변삭제시_질문자와_다를경우_예외발생() {
         User loginUser = UserTest.HOONHEE;
         assertThatThrownBy(() -> A1.delete(loginUser))

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -25,14 +25,15 @@ public class AnswerTest {
     }
 
     @Test
-    void 삭제시_삭제상태가_변경되는지_확인() throws CannotDeleteException {
+    void 삭제시_삭제상태가_변경되는지_확인() {
         User loginUser = UserTest.JAVAJIGI;
         A1.delete(loginUser);
         assertThat(A1.isDeleted()).isTrue();
     }
 
     @Test
-    void 삭제시_삭제이력을_반환하는지_확인() throws CannotDeleteException {
+    void 삭제시_삭제이력을_반환하는지_확인() {
+        //TODO - 답변삭제시 삭제 이력을 반환해야 한다.
         User loginUser = UserTest.JAVAJIGI;
         DeleteHistory deleteHistory = A1.delete(loginUser);
         assertThat(deleteHistory).isNotNull();

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,18 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import qna.exception.CannotDeleteException;
+
+public class AnswersTest {
+
+    @Test
+    void 답변삭제시_답변자중에서_질문자와_다른인물이_있을경우_예외발생() {
+        Answers answers = new Answers(AnswerTest.A2);
+
+        assertThatThrownBy(() -> answers.deleteAnswers(AnswerTest.A1.getWriter()))
+            .isInstanceOf(CannotDeleteException.class);
+    }
+
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,52 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import qna.exception.CannotDeleteException;
+
 public class QuestionTest {
+
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Test
+    void 삭제시_삭제상태가_변경되는지_확인() {
+        User loginUser = UserTest.JAVAJIGI;
+        Q1.delete(loginUser);
+        assertThat(Q1.isDeleted()).isTrue();
+    }
+
+    @Test
+    void 질문자와_로그인사용자가_동일한지_확인() {
+        User answerer = UserTest.JAVAJIGI;
+        assertThat(Q1.isOwner(answerer)).isTrue();
+    }
+
+    @Test
+    void 질문삭제시_답변자중에서_질문자와_다른인물이_있을경우_예외발생() {
+        Question question = new Question("질문입니다.", "질문내용입니다.").writeBy(UserTest.JAVAJIGI);
+        question.addAnswer(AnswerTest.A2);
+        assertThatThrownBy(() -> question.delete(UserTest.JAVAJIGI))
+            .isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    void 질문을_삭제하면_답변도_같이_삭제되는지_확인_SOFT삭제처리() {
+        Question question = new Question("질문입니다.", "질문내용입니다.").writeBy(UserTest.JAVAJIGI);
+        question.addAnswer(AnswerTest.A1);
+        question.delete(UserTest.JAVAJIGI);
+
+        assertThat(question.getAnswers().undeletedAnswers()).hasSize(0);
+    }
+
+    @Test
+    void 삭제시_삭제이력을_반환하는지_확인() {
+        Question question = new Question("질문입니다.", "질문내용입니다.").writeBy(UserTest.JAVAJIGI);
+        question.addAnswer(AnswerTest.A1);
+        DeleteHistories deleteHistories = question.delete(UserTest.JAVAJIGI);
+
+        assertThat(deleteHistories.getDeleteHistories()).hasSize(2);
+    }
 }

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -262,7 +262,8 @@ public class QuestionRepositoryTest {
 
         //When
         Question savedQuestion = questionRepository.findById(question.getId()).get();
-        List<Answer> answers = savedQuestion.getAnswers();
+
+        List<Answer> answers = savedQuestion.getAnswers().undeletedAnswers();
 
         //Then
         assertAll(

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -19,6 +19,7 @@ import qna.domain.User;
 @DataJpaTest
 public class QuestionRepositoryTest {
 
+    private static final boolean DELETED = true;
     @Autowired
     private QuestionRepository questionRepository;
 
@@ -136,7 +137,7 @@ public class QuestionRepositoryTest {
         List<Question> questions = new ArrayList<>();
         questions.add(new Question("질문있어요1", "내용입니다1", questioner));
         questions.add(new Question("질문있어요2", "내용입니다2", questioner));
-        questions.add(new Question("질문있어요3", "내용입니다3", questioner).setDeleted(true));
+        questions.add(new Question("질문있어요3", "내용입니다3", questioner, DELETED));
         questionRepository.saveAll(questions);
 
         //When
@@ -200,11 +201,11 @@ public class QuestionRepositoryTest {
         //Given
         User questioner = new User("test1", "1234", "홍길동", "hong@test.com");
         Question question = new Question("질문있어요", "내용입니다.", questioner);
-        questionRepository.save(question);
+        Question savedQuestion = questionRepository.save(question);
 
         //When
-        Question savedQuestion = questionRepository.findById(question.getId()).get();
-        savedQuestion.setTitle("제목 변경");
+        Question modifyQuestion = new Question("질문수정했어요", "내용수정했습니다.");
+        savedQuestion.update(modifyQuestion);
 
         //Then
         Question actual = questionRepository.findById(savedQuestion.getId()).get();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,6 +89,6 @@ class QnaServiceTest {
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
                 new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
-        verify(deleteHistoryService).saveAll(deleteHistories);
+        verify(deleteHistoryService).saveAll(new DeleteHistories(deleteHistories));
     }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -18,6 +18,7 @@ import qna.repository.QuestionRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,9 +26,6 @@ import static org.mockito.Mockito.when;
 class QnaServiceTest {
     @Mock
     private QuestionRepository questionRepository;
-
-    @Mock
-    private AnswerRepository answerRepository;
 
     @Mock
     private DeleteHistoryService deleteHistoryService;
@@ -39,16 +37,15 @@ class QnaServiceTest {
     private Answer answer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
         answer = new Answer(1L, UserTest.JAVAJIGI, question, "Answers Contents1");
         question.addAnswer(answer);
     }
 
     @Test
-    public void delete_성공() throws Exception {
+    public void delete_성공() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -58,7 +55,7 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_다른_사람이_쓴_글() throws Exception {
+    public void delete_다른_사람이_쓴_글() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.SANJIGI, question.getId()))
@@ -66,9 +63,8 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_성공_질문자_답변자_같음() throws Exception {
+    public void delete_성공_질문자_답변자_같음() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -78,12 +74,11 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
-        question.addAnswer(answer2);
+    public void delete_답변_중_다른_사람이_쓴_글() {
+        Answer answer = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
+        question.addAnswer(answer);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);


### PR DESCRIPTION
현구님 JPA 마지막 3단계 리뷰도 요청드립니다.
사실 어제 새벽에 잠을 안자고 3단계를 따로 진행을 해서 이렇게 3단계 리뷰도 빠르게 요청드리게 되었습니다.
QnaService 에서 처리하는 기능들을 도메인영역의 질문과 답변들로 이동시키고 TDD를 진행하고나니 QnaService에서는 별로 할것이 없더군요.
그냥 자연스럽게 DB데이터를 조회해오고 질문삭제기능은 도메인영역으로 연결만 시켜주었습니다.
삭제한 후 삭제이력결과를 마지막에 저장해주는것만 해주니까 금방 끝났습니다.
영속화된 객체들안에서 조작되는 데이터들은 모두 JPA가 알아서 DB로 반영을 해주니..
이것이야말로 객체지향적 프로그래밍이고, 새로운 개발방법이 아닌가 싶습니다. 전율이 느껴졌다고나 할까요.
그동안 제가 하던 프로그래밍은 객체지향이 아니라 절차지향적 프로그래밍이었던것 같습니다.
이제까지 제가 짜놓았던 기존의 쓰레기같은 레거시코드들도 JPA를 도입해서 TDD를 하여 리팩토링 할 수 있을것만 같습니다.
물론 처음에는 조금 버벅이겠지만요. 방법은 터득한것 같습니다.
그럼 마지막 리뷰도 부탁드리겠습니다~!
