### PR TITLE
[Step 2] 연관 관계 매핑 리뷰 요청 드립니다.

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -49,7 +49,6 @@ public class Answer {
 	private User user;
 
 	protected Answer() {
-
 	}
 
 	public Answer(User writer, Question question, String contents) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -95,8 +95,8 @@ public class Answer {
 		return deleted;
 	}
 
-	public void delete(boolean deleted) {
-		this.deleted = deleted;
+	public void delete() {
+		this.deleted = true;
 	}
 
 	@Override
@@ -108,15 +108,24 @@ public class Answer {
 		Answer answer = (Answer)o;
 		return deleted == answer.deleted &&
 			Objects.equals(id, answer.id) &&
-			Objects.equals(contents, answer.contents) &&
-			Objects.equals(createAt, answer.createAt) &&
-			Objects.equals(question, answer.question) &&
-			Objects.equals(updatedAt, answer.updatedAt) &&
-			Objects.equals(user, answer.user);
+			Objects.equals(contents, answer.contents);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(id, contents, createAt, deleted, question, updatedAt, user);
+	}
+
+	@Override
+	public String toString() {
+		return "Answer{" +
+			"id=" + id +
+			", contents='" + contents + '\'' +
+			", createAt=" + createAt +
+			", deleted=" + deleted +
+			", question=" + question +
+			", updatedAt=" + updatedAt +
+			", user=" + user +
+			'}';
 	}
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -84,10 +84,6 @@ public class Answer {
 		return id;
 	}
 
-	public Long getWriterId() {
-		return user.getId();
-	}
-
 	public User getWriter() {
 		return this.user;
 	}

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -7,10 +7,13 @@ import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import qna.NotFoundException;
@@ -34,14 +37,16 @@ public class Answer {
 	@Column(name = "deleted", nullable = false)
 	private boolean deleted = false;
 
-	@Column(name = "question_id")
-	private Long questionId;
+	@ManyToOne
+	@JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+	private Question question;
 
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
-	@Column(name = "writerId")
-	private Long writerId;
+	@ManyToOne
+	@JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
+	private User user;
 
 	protected Answer() {
 
@@ -62,49 +67,37 @@ public class Answer {
 			throw new NotFoundException();
 		}
 
-		this.writerId = writer.getId();
-		this.questionId = question.getId();
+		this.user = writer;
+		this.question = question;
 		this.contents = contents;
 	}
 
 	public boolean isOwner(User writer) {
-		return this.writerId.equals(writer.getId());
+		return this.user.equals(writer);
 	}
 
 	public void toQuestion(Question question) {
-		this.questionId = question.getId();
+		this.question = question;
 	}
 
 	public Long getId() {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public Long getWriterId() {
-		return writerId;
+		return user.getId();
 	}
 
-	public void setWriterId(Long writerId) {
-		this.writerId = writerId;
+	public User getWriter() {
+		return this.user;
 	}
 
-	public Long getQuestionId() {
-		return questionId;
-	}
-
-	public void setQuestionId(Long questionId) {
-		this.questionId = questionId;
+	public Question getQuestion() {
+		return question;
 	}
 
 	public String getContents() {
 		return contents;
-	}
-
-	public void setContents(String contents) {
-		this.contents = contents;
 	}
 
 	public boolean isDeleted() {
@@ -113,16 +106,5 @@ public class Answer {
 
 	public void setDeleted(boolean deleted) {
 		this.deleted = deleted;
-	}
-
-	@Override
-	public String toString() {
-		return "Answer{" +
-			"id=" + id +
-			", writerId=" + writerId +
-			", questionId=" + questionId +
-			", contents='" + contents + '\'' +
-			", deleted=" + deleted +
-			'}';
 	}
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -71,10 +71,6 @@ public class Answer {
 		this.contents = contents;
 	}
 
-	public boolean isOwner(User writer) {
-		return this.user.equals(writer);
-	}
-
 	public void toQuestion(Question question) {
 		this.question = question;
 	}
@@ -87,19 +83,19 @@ public class Answer {
 		return this.user;
 	}
 
-	public Question getQuestion() {
-		return question;
+	public boolean isOwner(User writer) {
+		return this.user.equals(writer);
 	}
 
-	public String getContents() {
-		return contents;
+	public boolean isAnsweredQuestion(Question question) {
+		return this.question.equals(question);
 	}
 
 	public boolean isDeleted() {
 		return deleted;
 	}
 
-	public void setDeleted(boolean deleted) {
+	public void delete(boolean deleted) {
 		this.deleted = deleted;
 	}
 
@@ -111,7 +107,12 @@ public class Answer {
 			return false;
 		Answer answer = (Answer)o;
 		return deleted == answer.deleted &&
-			Objects.equals(id, answer.id);
+			Objects.equals(id, answer.id) &&
+			Objects.equals(contents, answer.contents) &&
+			Objects.equals(createAt, answer.createAt) &&
+			Objects.equals(question, answer.question) &&
+			Objects.equals(updatedAt, answer.updatedAt) &&
+			Objects.equals(user, answer.user);
 	}
 
 	@Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -102,4 +102,20 @@ public class Answer {
 	public void setDeleted(boolean deleted) {
 		this.deleted = deleted;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Answer answer = (Answer)o;
+		return deleted == answer.deleted &&
+			Objects.equals(id, answer.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, contents, createAt, deleted, question, updatedAt, user);
+	}
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -50,28 +50,8 @@ public class DeleteHistory {
 		return id;
 	}
 
-	public Long getContentId() {
-		return contentId;
-	}
-
-	public ContentType getContentType() {
-		return contentType;
-	}
-
-	public LocalDateTime getCreateDate() {
-		return createDate;
-	}
-
-	public Long getDeletedById() {
-		return user.getId();
-	}
-
-	public User getDeleter() {
-		return user;
-	}
-
-	public void setDeletedByUser(User deletedByUser) {
-		this.user = deletedByUser;
+	public boolean isDeletedBy(User user) {
+		return this.user == user;
 	}
 
 	@Override

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -67,6 +67,10 @@ public class DeleteHistory {
 		return user.getId();
 	}
 
+	public User getDeleter() {
+		return user;
+	}
+
 	public void setDeletedById(User deletedByUser) {
 		this.user = deletedByUser;
 	}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -37,7 +37,6 @@ public class DeleteHistory {
 	private User user;
 
 	protected DeleteHistory() {
-
 	}
 
 	public DeleteHistory(ContentType contentType, Long contentId, User deletedByUser, LocalDateTime createDate) {
@@ -71,7 +70,7 @@ public class DeleteHistory {
 		return user;
 	}
 
-	public void setDeletedById(User deletedByUser) {
+	public void setDeletedByUser(User deletedByUser) {
 		this.user = deletedByUser;
 	}
 

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -7,9 +7,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -29,17 +32,18 @@ public class DeleteHistory {
 	@Column(name = "create_date")
 	private LocalDateTime createDate = LocalDateTime.now();
 
-	@Column(name = "deleted_by_id")
-	private Long deletedById;
+	@ManyToOne
+	@JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+	private User user;
 
 	protected DeleteHistory() {
 
 	}
 
-	public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+	public DeleteHistory(ContentType contentType, Long contentId, User deletedByUser, LocalDateTime createDate) {
 		this.contentType = contentType;
 		this.contentId = contentId;
-		this.deletedById = deletedById;
+		this.user = deletedByUser;
 		this.createDate = createDate;
 	}
 
@@ -47,40 +51,24 @@ public class DeleteHistory {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public Long getContentId() {
 		return contentId;
-	}
-
-	public void setContentId(Long contentId) {
-		this.contentId = contentId;
 	}
 
 	public ContentType getContentType() {
 		return contentType;
 	}
 
-	public void setContentType(ContentType contentType) {
-		this.contentType = contentType;
-	}
-
 	public LocalDateTime getCreateDate() {
 		return createDate;
 	}
 
-	public void setCreateDate(LocalDateTime createDate) {
-		this.createDate = createDate;
-	}
-
 	public Long getDeletedById() {
-		return deletedById;
+		return user.getId();
 	}
 
-	public void setDeletedById(Long deletedById) {
-		this.deletedById = deletedById;
+	public void setDeletedById(User deletedByUser) {
+		this.user = deletedByUser;
 	}
 
 	@Override
@@ -91,24 +79,13 @@ public class DeleteHistory {
 			return false;
 		DeleteHistory that = (DeleteHistory)o;
 		return Objects.equals(id, that.id) &&
-			contentType == that.contentType &&
 			Objects.equals(contentId, that.contentId) &&
-			Objects.equals(deletedById, that.deletedById);
+			contentType == that.contentType &&
+			Objects.equals(user, that.user);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, contentType, contentId, deletedById);
-	}
-
-	@Override
-	public String toString() {
-		return "DeleteHistory{" +
-			"id=" + id +
-			", contentType=" + contentType +
-			", contentId=" + contentId +
-			", deletedById=" + deletedById +
-			", createDate=" + createDate +
-			'}';
+		return Objects.hash(id, contentId, contentType, user);
 	}
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -37,15 +37,11 @@ public class Question {
 	private String title;
 
 	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
+	private LocalDateTime updatedAt = LocalDateTime.now();
 
 	@ManyToOne
 	@JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
 	private User user;
-
-	public void setWriter(final User user) {
-		this.user = user;
-	}
 
 	protected Question() {
 
@@ -89,6 +85,14 @@ public class Question {
 
 	public Long getWriterId() {
 		return user.getId();
+	}
+
+	public User getWriter() {
+		return this.user;
+	}
+
+	public void setWriter(final User user) {
+		this.user = user;
 	}
 
 	public boolean isDeleted() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -44,7 +44,6 @@ public class Question {
 	private User user;
 
 	protected Question() {
-
 	}
 
 	public Question(String title, String contents) {
@@ -101,5 +100,18 @@ public class Question {
 
 	public void setDeleted(boolean deleted) {
 		this.deleted = deleted;
+	}
+
+	@Override
+	public String toString() {
+		return "Question{" +
+			"id=" + id +
+			", contents='" + contents + '\'' +
+			", createAt=" + createAt +
+			", deleted=" + deleted +
+			", title='" + title + '\'' +
+			", updatedAt=" + updatedAt +
+			", user=" + user +
+			'}';
 	}
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -83,24 +83,8 @@ public class Question {
 		return id;
 	}
 
-	public String getTitle() {
-		return title;
-	}
-
-	public String getContents() {
-		return contents;
-	}
-
-	public Long getWriterId() {
-		return user.getId();
-	}
-
 	public User getWriter() {
 		return this.user;
-	}
-
-	public void setWriter(final User user) {
-		this.user = user;
 	}
 
 	public boolean isDeleted() {
@@ -111,7 +95,7 @@ public class Question {
 		this.deleted = deleted;
 	}
 
-	public boolean isContaioned(Answer answer) {
+	public boolean isContained(Answer answer) {
 		return answers.contains(answer);
 	}
 
@@ -123,7 +107,11 @@ public class Question {
 			return false;
 		Question question = (Question)o;
 		return deleted == question.deleted &&
-			Objects.equals(id, question.id);
+			Objects.equals(id, question.id) &&
+			Objects.equals(contents, question.contents) &&
+			Objects.equals(title, question.title) &&
+			Objects.equals(user, question.user) &&
+			Objects.equals(answers, question.answers);
 	}
 
 	@Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -91,8 +91,8 @@ public class Question {
 		return deleted;
 	}
 
-	public void delete(boolean deleted) {
-		this.deleted = deleted;
+	public void delete() {
+		this.deleted = true;
 	}
 
 	public boolean isContained(Answer answer) {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,8 +1,12 @@
 package qna.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 @Entity
@@ -43,6 +48,9 @@ public class Question {
 	@JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
 	private User user;
 
+	@OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Answer> answers = new ArrayList<>();
+
 	protected Question() {
 	}
 
@@ -57,7 +65,7 @@ public class Question {
 	}
 
 	public Question writtenBy(User writer) {
-		setWriter(writer);
+		this.user = writer;
 
 		return this;
 	}
@@ -68,6 +76,7 @@ public class Question {
 
 	public void addAnswer(Answer answer) {
 		answer.toQuestion(this);
+		answers.add(answer);
 	}
 
 	public Long getId() {
@@ -98,8 +107,28 @@ public class Question {
 		return deleted;
 	}
 
-	public void setDeleted(boolean deleted) {
+	public void delete(boolean deleted) {
 		this.deleted = deleted;
+	}
+
+	public boolean isContaioned(Answer answer) {
+		return answers.contains(answer);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Question question = (Question)o;
+		return deleted == question.deleted &&
+			Objects.equals(id, question.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, contents, createAt, deleted, title, updatedAt, user, answers);
 	}
 
 	@Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -6,10 +6,13 @@ import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -36,8 +39,13 @@ public class Question {
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
-	@Column(name = "writer_id")
-	private Long writerId;
+	@ManyToOne
+	@JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
+	private User user;
+
+	public void setWriter(final User user) {
+		this.user = user;
+	}
 
 	protected Question() {
 
@@ -53,13 +61,14 @@ public class Question {
 		this.contents = contents;
 	}
 
-	public Question writeBy(User writer) {
-		this.writerId = writer.getId();
+	public Question writtenBy(User writer) {
+		setWriter(writer);
+
 		return this;
 	}
 
 	public boolean isOwner(User writer) {
-		return this.writerId.equals(writer.getId());
+		return this.user.equals(writer);
 	}
 
 	public void addAnswer(Answer answer) {
@@ -70,32 +79,16 @@ public class Question {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public String getTitle() {
 		return title;
-	}
-
-	public void setTitle(String title) {
-		this.title = title;
 	}
 
 	public String getContents() {
 		return contents;
 	}
 
-	public void setContents(String contents) {
-		this.contents = contents;
-	}
-
 	public Long getWriterId() {
-		return writerId;
-	}
-
-	public void setWriterId(Long writerId) {
-		this.writerId = writerId;
+		return user.getId();
 	}
 
 	public boolean isDeleted() {
@@ -104,16 +97,5 @@ public class Question {
 
 	public void setDeleted(boolean deleted) {
 		this.deleted = deleted;
-	}
-
-	@Override
-	public String toString() {
-		return "Question{" +
-			"id=" + id +
-			", title='" + title + '\'' +
-			", contents='" + contents + '\'' +
-			", writerId=" + writerId +
-			", deleted=" + deleted +
-			'}';
 	}
 }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -88,26 +88,6 @@ public class User {
 		return false;
 	}
 
-	public Long getId() {
-		return id;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public String getEmail() {
-		return email;
-	}
-
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)
@@ -115,7 +95,11 @@ public class User {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		User user = (User)o;
-		return Objects.equals(id, user.id);
+		return Objects.equals(id, user.id) &&
+			Objects.equals(email, user.email) &&
+			Objects.equals(name, user.name) &&
+			Objects.equals(password, user.password) &&
+			Objects.equals(userId, user.userId);
 	}
 
 	@Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -130,6 +130,21 @@ public class User {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		User user = (User)o;
+		return Objects.equals(id, user.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, createAt, email, name, password, updatedAt, userId);
+	}
+
+	@Override
 	public String toString() {
 		return "User{" +
 			"id=" + id +

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -34,13 +34,12 @@ public class User {
 	private String password;
 
 	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
+	private LocalDateTime updatedAt = LocalDateTime.now();
 
 	@Column(name = "user_id", nullable = false, length = 20, unique = true)
 	private String userId;
 
 	protected User() {
-
 	}
 
 	public User(String userId, String password, String name, String email) {
@@ -93,40 +92,20 @@ public class User {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public String getUserId() {
 		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getPassword() {
 		return password;
 	}
 
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
 	public String getName() {
 		return name;
 	}
 
-	public void setName(String name) {
-		this.name = name;
-	}
-
 	public String getEmail() {
 		return email;
-	}
-
-	public void setEmail(String email) {
-		this.email = email;
 	}
 
 	@Override
@@ -142,17 +121,6 @@ public class User {
 	@Override
 	public int hashCode() {
 		return Objects.hash(id, createAt, email, name, password, updatedAt, userId);
-	}
-
-	@Override
-	public String toString() {
-		return "User{" +
-			"id=" + id +
-			", userId='" + userId + '\'' +
-			", password='" + password + '\'' +
-			", name='" + name + '\'' +
-			", email='" + email + '\'' +
-			'}';
 	}
 
 	private static class GuestUser extends User {

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -1,15 +1,12 @@
 package qna.domain;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByUserId(String userId);
-
 	@Query(value = "SELECT userId FROM User WHERE email like %:emailPiece%")
 	List<Object[]> findByEmail(@Param("emailPiece") String emailPiece);
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -55,11 +55,11 @@ public class QnaService {
 		}
 
 		List<DeleteHistory> deleteHistories = new ArrayList<>();
-		question.delete(true);
+		question.delete();
 		deleteHistories.add(
 			new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
 		for (Answer answer : answers) {
-			answer.setDeleted(true);
+			answer.delete();
 			deleteHistories.add(
 				new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
 		}

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -55,7 +55,7 @@ public class QnaService {
 		}
 
 		List<DeleteHistory> deleteHistories = new ArrayList<>();
-		question.setDeleted(true);
+		question.delete(true);
 		deleteHistories.add(
 			new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
 		for (Answer answer : answers) {

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -1,58 +1,68 @@
 package qna.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import qna.CannotDeleteException;
-import qna.NotFoundException;
-import qna.domain.*;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import qna.CannotDeleteException;
+import qna.NotFoundException;
+import qna.domain.Answer;
+import qna.domain.AnswerRepository;
+import qna.domain.ContentType;
+import qna.domain.DeleteHistory;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
+
 @Service
 public class QnaService {
-    private static final Logger log = LoggerFactory.getLogger(QnaService.class);
+	private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
-    private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
-    private DeleteHistoryService deleteHistoryService;
+	private QuestionRepository questionRepository;
+	private AnswerRepository answerRepository;
+	private DeleteHistoryService deleteHistoryService;
 
-    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
-        this.questionRepository = questionRepository;
-        this.answerRepository = answerRepository;
-        this.deleteHistoryService = deleteHistoryService;
-    }
+	public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository,
+		DeleteHistoryService deleteHistoryService) {
+		this.questionRepository = questionRepository;
+		this.answerRepository = answerRepository;
+		this.deleteHistoryService = deleteHistoryService;
+	}
 
-    @Transactional(readOnly = true)
-    public Question findQuestionById(Long id) {
-        return questionRepository.findByIdAndDeletedFalse(id)
-                .orElseThrow(NotFoundException::new);
-    }
+	@Transactional(readOnly = true)
+	public Question findQuestionById(Long id) {
+		return questionRepository.findByIdAndDeletedFalse(id)
+			.orElseThrow(NotFoundException::new);
+	}
 
-    @Transactional
-    public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
-        Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+	@Transactional
+	public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
+		Question question = findQuestionById(questionId);
+		if (!question.isOwner(loginUser)) {
+			throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+		}
 
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+		List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
+		for (Answer answer : answers) {
+			if (!answer.isOwner(loginUser)) {
+				throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+			}
+		}
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
-    }
+		List<DeleteHistory> deleteHistories = new ArrayList<>();
+		question.setDeleted(true);
+		deleteHistories.add(
+			new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
+		for (Answer answer : answers) {
+			answer.setDeleted(true);
+			deleteHistories.add(
+				new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+		}
+		deleteHistoryService.saveAll(deleteHistories);
+	}
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -19,6 +19,19 @@ public class AnswerTest {
 	private QuestionRepository questions;
 
 	@Test
+	@DisplayName("답변을 조회하고 연관된 질문 및 작성자를 조회")
+	void select_not_deleted_question_with_writer() {
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question saveQ1 = questions.save(Q1);
+		Answer saveA1 = answers.save(new Answer(saveJavajigi, saveQ1, "Answers Contents1"));
+
+		assertThat(saveA1.getWriter().getUserId()).isEqualTo("javajigi");
+		assertThat(saveA1.getQuestion().getTitle()).isEqualTo("title1");
+	}
+
+	@Test
 	@DisplayName("jpa 데이터 인서트")
 	void save() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -12,17 +12,24 @@ public class AnswerTest {
 	@Autowired
 	private AnswerRepository answers;
 
+	@Autowired
+	private UserRepository users;
+
+	@Autowired
+	private QuestionRepository questions;
+
 	@Test
 	@DisplayName("jpa 데이터 인서트")
 	void save() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
-		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
+		User saveJavajigi = users.save(JAVAJIGI);
+		User saveSanjigi = users.save(SANJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question saveQ1 = questions.save(Q1);
 
-		answers.save(A1);
-		answers.save(A2);
+		Answer saveA1 = answers.save(new Answer(saveJavajigi, saveQ1, "Answers Contents1"));
+		Answer saveA2 = answers.save(new Answer(saveSanjigi, saveQ1, "Answers Contents2"));
 
 		assertThat(answers.count()).isEqualTo(2);
 	}
@@ -31,9 +38,10 @@ public class AnswerTest {
 	@DisplayName("jpa 데이터 인서트 후 동일성 확인")
 	void is_same_object() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
-
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question saveQ1 = questions.save(Q1);
+		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
 		Answer saveA1 = answers.save(A1);
 
 		assertThat(saveA1).isEqualTo(answers.findById(saveA1.getId()).get());
@@ -43,12 +51,14 @@ public class AnswerTest {
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		User saveJavajigi = users.save(JAVAJIGI);
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
-		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
-
+		User saveSanjigi = users.save(SANJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question saveQ1 = questions.save(Q1);
+		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
 		Answer saveA1 = answers.save(A1);
+		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
 		A2.setDeleted(true);
 		Answer saveA2 = answers.save(A2);
 
@@ -60,12 +70,14 @@ public class AnswerTest {
 	@DisplayName("jpa 작성 메소드 사용(findByQuestionIdAndDeletedFalse)")
 	void use_written_method_findByQuestionIdAndDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		User saveJavajigi = users.save(JAVAJIGI);
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
-		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
-
+		User saveSanjigi = users.save(SANJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question saveQ1 = questions.save(Q1);
+		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
 		Answer saveA1 = answers.save(A1);
+		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
 		A2.setDeleted(true);
 		Answer saveA2 = answers.save(A2);
 

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -25,8 +25,8 @@ public class AnswerTest {
 		Question saveQ1 = saveQuestion1(saveJavajigi);
 		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 
-		assertThat(saveA1.getWriter().getUserId()).isEqualTo("javajigi");
-		assertThat(saveA1.getQuestion().getTitle()).isEqualTo("title1");
+		assertThat(saveA1.getWriter()).isEqualTo(saveJavajigi);
+		assertThat(saveA1.isAnsweredQuestion(saveQ1)).isTrue();
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class AnswerTest {
 		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 		User saveSanjigi = saveSanjigi();
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
-		A2.setDeleted(true);
+		A2.delete(true);
 		Answer saveA2 = answers.save(A2);
 
 		assertThat(saveA1).isEqualTo(answers.findByIdAndDeletedFalse(saveA1.getId()).get());
@@ -73,7 +73,7 @@ public class AnswerTest {
 		Question saveQ1 = saveQuestion1(saveJavajigi);
 		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
-		A2.setDeleted(true);
+		A2.delete(true);
 		Answer saveA2 = answers.save(A2);
 
 		assertThat(answers.findByQuestionIdAndDeletedFalse(saveQ1.getId()).size()).isEqualTo(1);

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -58,7 +58,7 @@ public class AnswerTest {
 		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 		User saveSanjigi = saveSanjigi();
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
-		A2.delete(true);
+		A2.delete();
 		Answer saveA2 = answers.save(A2);
 
 		assertThat(saveA1).isEqualTo(answers.findByIdAndDeletedFalse(saveA1.getId()).get());
@@ -73,7 +73,7 @@ public class AnswerTest {
 		Question saveQ1 = saveQuestion1(saveJavajigi);
 		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
-		A2.delete(true);
+		A2.delete();
 		Answer saveA2 = answers.save(A2);
 
 		assertThat(answers.findByQuestionIdAndDeletedFalse(saveQ1.getId()).size()).isEqualTo(1);

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -21,11 +21,9 @@ public class AnswerTest {
 	@Test
 	@DisplayName("답변을 조회하고 연관된 질문 및 작성자를 조회")
 	void select_not_deleted_question_with_writer() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-		Answer saveA1 = answers.save(new Answer(saveJavajigi, saveQ1, "Answers Contents1"));
+		User saveJavajigi = saveJavajigi();
+		Question saveQ1 = saveQuestion1(saveJavajigi);
+		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 
 		assertThat(saveA1.getWriter().getUserId()).isEqualTo("javajigi");
 		assertThat(saveA1.getQuestion().getTitle()).isEqualTo("title1");
@@ -34,15 +32,10 @@ public class AnswerTest {
 	@Test
 	@DisplayName("jpa 데이터 인서트")
 	void save() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		User saveJavajigi = users.save(JAVAJIGI);
-		User saveSanjigi = users.save(SANJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-
-		Answer saveA1 = answers.save(new Answer(saveJavajigi, saveQ1, "Answers Contents1"));
-		Answer saveA2 = answers.save(new Answer(saveSanjigi, saveQ1, "Answers Contents2"));
+		User saveJavajigi = saveJavajigi();
+		Question saveQ1 = saveQuestion1(saveJavajigi);
+		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
+		Answer saveA2 = saveAnswer2(saveJavajigi, saveQ1);
 
 		assertThat(answers.count()).isEqualTo(2);
 	}
@@ -50,12 +43,9 @@ public class AnswerTest {
 	@Test
 	@DisplayName("jpa 데이터 인서트 후 동일성 확인")
 	void is_same_object() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
-		Answer saveA1 = answers.save(A1);
+		User saveJavajigi = saveJavajigi();
+		Question saveQ1 = saveQuestion1(saveJavajigi);
+		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 
 		assertThat(saveA1).isEqualTo(answers.findById(saveA1.getId()).get());
 	}
@@ -63,14 +53,10 @@ public class AnswerTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User saveJavajigi = users.save(JAVAJIGI);
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		User saveSanjigi = users.save(SANJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
-		Answer saveA1 = answers.save(A1);
+		User saveJavajigi = saveJavajigi();
+		Question saveQ1 = saveQuestion1(saveJavajigi);
+		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
+		User saveSanjigi = saveSanjigi();
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
 		A2.setDeleted(true);
 		Answer saveA2 = answers.save(A2);
@@ -82,21 +68,45 @@ public class AnswerTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByQuestionIdAndDeletedFalse)")
 	void use_written_method_findByQuestionIdAndDeletedFalse() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User saveJavajigi = users.save(JAVAJIGI);
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		User saveSanjigi = users.save(SANJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-		Answer A1 = new Answer(saveJavajigi, saveQ1, "Answers Contents1");
-		Answer saveA1 = answers.save(A1);
+		User saveJavajigi = saveJavajigi();
+		User saveSanjigi = saveSanjigi();
+		Question saveQ1 = saveQuestion1(saveJavajigi);
+		Answer saveA1 = saveAnswer1(saveJavajigi, saveQ1);
 		Answer A2 = new Answer(saveSanjigi, saveQ1, "Answers Contents2");
 		A2.setDeleted(true);
 		Answer saveA2 = answers.save(A2);
 
-		assertThat(answers.findByQuestionIdAndDeletedFalse(Q1.getId()).size()).isEqualTo(1);
-		assertThat(saveA1).isEqualTo(answers.findByQuestionIdAndDeletedFalse(Q1.getId()).get(0));
-		assertThat(answers.findByQuestionIdAndDeletedFalse(Q1.getId()).get(0)).isEqualTo(
+		assertThat(answers.findByQuestionIdAndDeletedFalse(saveQ1.getId()).size()).isEqualTo(1);
+		assertThat(saveA1).isEqualTo(answers.findByQuestionIdAndDeletedFalse(saveQ1.getId()).get(0));
+		assertThat(answers.findByQuestionIdAndDeletedFalse(saveQ1.getId()).get(0)).isEqualTo(
 			answers.findById(saveA1.getId()).get());
+	}
+
+	private User saveJavajigi() {
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		return users.save(JAVAJIGI);
+	}
+
+	private User saveSanjigi() {
+		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+		return users.save(SANJIGI);
+	}
+
+	private Question saveQuestion1(User user) {
+		Question Q1 = new Question("title1", "contents1").writtenBy(user);
+		return questions.save(Q1);
+	}
+
+	private Question saveQuestion2(User user) {
+		Question Q2 = new Question("title2", "contents2").writtenBy(user);
+		return questions.save(Q2);
+	}
+
+	private Answer saveAnswer1(User user, Question question) {
+		return answers.save(new Answer(user, question, "Answers Contents1"));
+	}
+
+	private Answer saveAnswer2(User user, Question question) {
+		return answers.save(new Answer(user, question, "Answers Contents2"));
 	}
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -17,7 +17,7 @@ public class AnswerTest {
 	void save() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
 		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
 
@@ -31,7 +31,7 @@ public class AnswerTest {
 	@DisplayName("jpa 데이터 인서트 후 동일성 확인")
 	void is_same_object() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
 
 		Answer saveA1 = answers.save(A1);
@@ -44,7 +44,7 @@ public class AnswerTest {
 	void use_written_method_findByIdAndDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
 		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
 
@@ -61,7 +61,7 @@ public class AnswerTest {
 	void use_written_method_findByQuestionIdAndDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 		Answer A1 = new Answer(JAVAJIGI, Q1, "Answers Contents1");
 		Answer A2 = new Answer(SANJIGI, Q1, "Answers Contents2");
 

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -20,9 +20,10 @@ public class DeleteHistoryTest {
 	@Test
 	@DisplayName("삭제를 조회하고 삭제한 사람을 조회한다.")
 	void select_not_deleted_question_with_writer() {
-		DeleteHistory saveDH1 = saveDeleteHistory1(saveJavajigi());
+		User sanjigi = saveJavajigi();
+		DeleteHistory saveDH1 = saveDeleteHistory1(sanjigi);
 
-		assertThat(saveDH1.getDeleter().getUserId()).isEqualTo("javajigi");
+		assertThat(saveDH1.isDeletedBy(sanjigi)).isTrue();
 	}
 
 	@Test

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -20,13 +20,7 @@ public class DeleteHistoryTest {
 	@Test
 	@DisplayName("삭제를 조회하고 삭제한 사람을 조회한다.")
 	void select_not_deleted_question_with_writer() {
-
-		User JAVAJIGI = makeJavajigi();
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
-			LocalDateTime.of(2021, 6, 2, 22, 30));
-		deleteHistories.flush();
-
-		DeleteHistory saveDH1 = deleteHistories.save(DH1);
+		DeleteHistory saveDH1 = saveDeleteHistory1(saveJavajigi());
 
 		assertThat(saveDH1.getDeleter().getUserId()).isEqualTo("javajigi");
 	}
@@ -34,17 +28,8 @@ public class DeleteHistoryTest {
 	@Test
 	@DisplayName("jpa between 조회")
 	void select_between() {
-		User JAVAJIGI = makeJavajigi();
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
-			LocalDateTime.of(2021, 6, 2, 22, 30));
-		DeleteHistory saveDH1 = deleteHistories.save(DH1);
-		deleteHistories.flush();
-
-		User SANJIGI = makeSanjigi();
-		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, users.save(SANJIGI),
-			LocalDateTime.of(2021, 6, 2, 23, 10));
-		DeleteHistory saveDH2 = deleteHistories.save(DH2);
-		deleteHistories.flush();
+		DeleteHistory saveDH1 = saveDeleteHistory1(saveJavajigi());
+		DeleteHistory saveDH2 = saveDeleteHistory2(saveSanjigi());
 
 		assertThat(
 			deleteHistories.findByCreateDateBetween(LocalDateTime.of(2021, 6, 2, 22, 10),
@@ -59,28 +44,33 @@ public class DeleteHistoryTest {
 	@Test
 	@DisplayName("jpa less than 조회")
 	void select_less_than() {
-		User JAVAJIGI = makeJavajigi();
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
-			LocalDateTime.of(2021, 6, 2, 22, 30));
-		DeleteHistory saveDH1 = deleteHistories.save(DH1);
-		deleteHistories.flush();
-
-		User SANJIGI = makeSanjigi();
-		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, users.save(SANJIGI),
-			LocalDateTime.of(2021, 6, 2, 23, 10));
-		DeleteHistory saveDH2 = deleteHistories.save(DH2);
-		deleteHistories.flush();
+		DeleteHistory saveDH1 = saveDeleteHistory1(saveJavajigi());
+		DeleteHistory saveDH2 = saveDeleteHistory2(saveSanjigi());
 
 		assertThat(
 			deleteHistories.findByIdLessThan(saveDH2.getId()).get(0)).isEqualTo(saveDH1
 		);
 	}
 
-	private User makeSanjigi() {
-		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+	private User saveJavajigi() {
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		return users.save(JAVAJIGI);
 	}
 
-	private User makeJavajigi() {
-		return new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+	private User saveSanjigi() {
+		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+		return users.save(SANJIGI);
+	}
+
+	private DeleteHistory saveDeleteHistory1(User user) {
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(user),
+			LocalDateTime.of(2021, 6, 2, 22, 30));
+		return deleteHistories.save(DH1);
+	}
+
+	private DeleteHistory saveDeleteHistory2(User user) {
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(user),
+			LocalDateTime.of(2021, 6, 2, 23, 10));
+		return deleteHistories.save(DH1);
 	}
 }

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,29 +17,34 @@ public class DeleteHistoryTest {
 	@Autowired
 	UserRepository users;
 
-	@BeforeEach
-	void setUp() {
-		deleteHistories.deleteAll();
+	@Test
+	@DisplayName("삭제를 조회하고 삭제한 사람을 조회한다.")
+	void select_not_deleted_question_with_writer() {
+
+		User JAVAJIGI = makeJavajigi();
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
+			LocalDateTime.of(2021, 6, 2, 22, 30));
 		deleteHistories.flush();
-		users.deleteAll();
-		users.flush();
+
+		DeleteHistory saveDH1 = deleteHistories.save(DH1);
+
+		assertThat(saveDH1.getDeleter().getUserId()).isEqualTo("javajigi");
 	}
 
 	@Test
 	@DisplayName("jpa between 조회")
 	void select_between() {
 		User JAVAJIGI = makeJavajigi();
-		users.save(JAVAJIGI);
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, JAVAJIGI,
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
 			LocalDateTime.of(2021, 6, 2, 22, 30));
+		DeleteHistory saveDH1 = deleteHistories.save(DH1);
+		deleteHistories.flush();
 
 		User SANJIGI = makeSanjigi();
-		users.save(SANJIGI);
-		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, SANJIGI,
+		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, users.save(SANJIGI),
 			LocalDateTime.of(2021, 6, 2, 23, 10));
-
-		DeleteHistory saveDH1 = deleteHistories.save(DH1);
 		DeleteHistory saveDH2 = deleteHistories.save(DH2);
+		deleteHistories.flush();
 
 		assertThat(
 			deleteHistories.findByCreateDateBetween(LocalDateTime.of(2021, 6, 2, 22, 10),

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +15,28 @@ public class DeleteHistoryTest {
 	@Autowired
 	private DeleteHistoryRepository deleteHistories;
 
+	@Autowired
+	UserRepository users;
+
+	@BeforeEach
+	void setUp() {
+		deleteHistories.deleteAll();
+		deleteHistories.flush();
+		users.deleteAll();
+		users.flush();
+	}
+
 	@Test
 	@DisplayName("jpa between 조회")
 	void select_between() {
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, 1L,
+		User JAVAJIGI = makeJavajigi();
+		users.save(JAVAJIGI);
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, JAVAJIGI,
 			LocalDateTime.of(2021, 6, 2, 22, 30));
-		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, 2L,
+
+		User SANJIGI = makeSanjigi();
+		users.save(SANJIGI);
+		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, SANJIGI,
 			LocalDateTime.of(2021, 6, 2, 23, 10));
 
 		DeleteHistory saveDH1 = deleteHistories.save(DH1);
@@ -38,16 +55,28 @@ public class DeleteHistoryTest {
 	@Test
 	@DisplayName("jpa less than 조회")
 	void select_less_than() {
-		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, 1L,
+		User JAVAJIGI = makeJavajigi();
+		DeleteHistory DH1 = new DeleteHistory(ContentType.ANSWER, 1L, users.save(JAVAJIGI),
 			LocalDateTime.of(2021, 6, 2, 22, 30));
-		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, 2L,
-			LocalDateTime.of(2021, 6, 2, 23, 10));
-
 		DeleteHistory saveDH1 = deleteHistories.save(DH1);
+		deleteHistories.flush();
+
+		User SANJIGI = makeSanjigi();
+		DeleteHistory DH2 = new DeleteHistory(ContentType.QUESTION, 2L, users.save(SANJIGI),
+			LocalDateTime.of(2021, 6, 2, 23, 10));
 		DeleteHistory saveDH2 = deleteHistories.save(DH2);
+		deleteHistories.flush();
 
 		assertThat(
 			deleteHistories.findByIdLessThan(saveDH2.getId()).get(0)).isEqualTo(saveDH1
 		);
+	}
+
+	private User makeSanjigi() {
+		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+	}
+
+	private User makeJavajigi() {
+		return new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 	}
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -70,11 +70,12 @@ public class QuestionTest {
 	@Test
 	@DisplayName("질문을 조회하고 해당 질문의 작성자를 조회함")
 	void select_not_deleted_question_with_writer() {
-		Question saveQ1 = saveQ1(saveJavajigi());
+		User javajigi = saveJavajigi();
+		Question saveQ1 = saveQ1(javajigi);
 
 		Question question = questions.findByIdAndDeletedFalse(saveQ1.getId()).get();
 
-		assertThat(question.getWriter().getUserId()).isEqualTo("javajigi");
+		assertThat(question.isOwner(javajigi)).isTrue();
 	}
 
 	@Test

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -16,6 +16,25 @@ public class QuestionTest {
 	UserRepository users;
 
 	@Test
+	@DisplayName("작성자 업데이트 확인")
+	void update_writer() {
+		User JAVAJIGI = makeJavajigi();
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+
+		users.save(JAVAJIGI);
+		Question saveQ1 = questions.save(Q1);
+
+		User SANJIGI = makeSanjigi();
+		users.save(SANJIGI);
+		saveQ1.setWriter(SANJIGI);
+		questions.flush();
+
+		Question expected = questions.findById(saveQ1.getId()).get();
+
+		assertThat(expected.getWriter().getUserId()).isEqualTo("sanjigi");
+	}
+
+	@Test
 	@DisplayName("user 를 만들지 않고 question 을 넣으면 에러 발생")
 	void fk_error() {
 		User JAVAJIGI = makeJavajigi();

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -32,7 +32,7 @@ public class QuestionTest {
 		testEntityManager.clear();
 
 		assertThat(questions.findAll().size()).isEqualTo(1);
-		assertThat(questions.findAll().get(0).isContaioned(answer)).isTrue();
+		assertThat(questions.findAll().get(0).isContained(answer)).isTrue();
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public class QuestionTest {
 		Question saveQ1 = saveQ1(saveJavajigi());
 
 		Question expected = questions.findById(saveQ1.getId()).get();
-		expected.setWriter(null);
+		expected.writtenBy(null);
 
 		assertThat(expected.getWriter()).isNull();
 	}
@@ -49,12 +49,13 @@ public class QuestionTest {
 	@Test
 	@DisplayName("작성자 업데이트 확인")
 	void update_writer() {
-		Question saveQ1 = saveQ1(saveJavajigi());
-		saveQ1.setWriter(saveSanjigi());
+		User sanjigi = saveJavajigi();
+		Question saveQ1 = saveQ1(sanjigi);
+		saveQ1.writtenBy(sanjigi);
 
 		Question expected = questions.findById(saveQ1.getId()).get();
 
-		assertThat(expected.getWriter().getUserId()).isEqualTo("sanjigi");
+		assertThat(expected.getWriter()).isEqualTo(sanjigi);
 	}
 
 	@Test
@@ -91,12 +92,9 @@ public class QuestionTest {
 	void use_written_method_findByDeletedFalse() {
 		User saveJavajigi = saveJavajigi();
 		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Q1.delete(true);
+		Q1.delete();
 		questions.save(Q1);
 		assertThat(questions.findByDeletedFalse().size()).isEqualTo(0);
-
-		Q1.delete(false);
-		assertThat(questions.findByDeletedFalse().size()).isEqualTo(1);
 	}
 
 	@Test
@@ -106,7 +104,7 @@ public class QuestionTest {
 
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId())).isEqualTo(questions.findById(saveQ1.getId()));
 
-		saveQ1.delete(true);
+		saveQ1.delete();
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId()).isPresent()).isFalse();
 	}
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -2,7 +2,6 @@ package qna.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,23 +12,20 @@ public class QuestionTest {
 	@Autowired
 	QuestionRepository questions;
 
-	@BeforeEach
-	void setUp() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
-		Question Q2 = new Question("title2", "contents2").writeBy(SANJIGI);
-	}
+	@Autowired
+	UserRepository users;
 
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByTitleContainingOrderByIdDesc)")
 	void select_start_with_order_by_id_desc() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
-		Question Q2 = new Question("title2", "contents2").writeBy(SANJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+		Question Q2 = new Question("title2", "contents2").writtenBy(SANJIGI);
 
+		users.save(JAVAJIGI);
 		questions.save(Q1);
+		users.save(SANJIGI);
 		questions.save(Q2);
 
 		assertThat(questions.findByTitleContainingOrderByIdDesc("title").get(0)).isEqualTo(
@@ -40,8 +36,9 @@ public class QuestionTest {
 	@DisplayName("jpa 작성 메소드 사용(findByDeletedFalse)")
 	void use_written_method_findByDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
+		users.save(JAVAJIGI);
 		Q1.setDeleted(true);
 		questions.save(Q1);
 		assertThat(questions.findByDeletedFalse().size()).isEqualTo(0);
@@ -54,11 +51,11 @@ public class QuestionTest {
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
+		users.save(JAVAJIGI);
 		Question saveQ1 = questions.save(Q1);
-		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId())).isEqualTo(
-			questions.findById(saveQ1.getId()));
+		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId())).isEqualTo(questions.findById(saveQ1.getId()));
 
 		saveQ1.setDeleted(true);
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId()).isPresent()).isFalse();

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -16,6 +16,22 @@ public class QuestionTest {
 	UserRepository users;
 
 	@Test
+	@DisplayName("연관관계 제거")
+	void delete_writer() {
+		User JAVAJIGI = makeJavajigi();
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+
+		users.save(JAVAJIGI);
+		Question saveQ1 = questions.save(Q1);
+
+		Question expected = questions.findById(saveQ1.getId()).get();
+		expected.setWriter(null);
+		questions.flush();
+
+		assertThat(expected.getWriter()).isNull();
+	}
+
+	@Test
 	@DisplayName("작성자 업데이트 확인")
 	void update_writer() {
 		User JAVAJIGI = makeJavajigi();

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -19,14 +19,12 @@ public class QuestionTest {
 	@DisplayName("연관관계 제거")
 	void delete_writer() {
 		User JAVAJIGI = makeJavajigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-
-		users.save(JAVAJIGI);
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Question saveQ1 = questions.save(Q1);
 
 		Question expected = questions.findById(saveQ1.getId()).get();
 		expected.setWriter(null);
-		questions.flush();
 
 		assertThat(expected.getWriter()).isNull();
 	}
@@ -35,15 +33,13 @@ public class QuestionTest {
 	@DisplayName("작성자 업데이트 확인")
 	void update_writer() {
 		User JAVAJIGI = makeJavajigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-
-		users.save(JAVAJIGI);
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Question saveQ1 = questions.save(Q1);
 
 		User SANJIGI = makeSanjigi();
-		users.save(SANJIGI);
-		saveQ1.setWriter(SANJIGI);
-		questions.flush();
+		User saveSanjigi = users.save(SANJIGI);
+		saveQ1.setWriter(saveSanjigi);
 
 		Question expected = questions.findById(saveQ1.getId()).get();
 
@@ -63,9 +59,8 @@ public class QuestionTest {
 	@DisplayName("질문을 조회하고 해당 질문의 작성자를 조회함")
 	void select_not_deleted_question_with_writer() {
 		User JAVAJIGI = makeJavajigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-
-		users.save(JAVAJIGI);
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Question saveQ1 = questions.save(Q1);
 
 		Question question = questions.findByIdAndDeletedFalse(saveQ1.getId()).get();
@@ -77,26 +72,30 @@ public class QuestionTest {
 	@DisplayName("jpa 작성 메소드 사용(findByTitleContainingOrderByIdDesc)")
 	void select_start_with_order_by_id_desc() {
 		User JAVAJIGI = makeJavajigi();
+		User saveJavajigi = users.save(JAVAJIGI);
 		User SANJIGI = makeSanjigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-		Question Q2 = new Question("title2", "contents2").writtenBy(SANJIGI);
+		User saveSanjigi = users.save(SANJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
+		Question Q2 = new Question("title2", "contents2").writtenBy(saveSanjigi);
 
-		users.save(JAVAJIGI);
-		questions.save(Q1);
-		users.save(SANJIGI);
-		questions.save(Q2);
+		Question saveQ1 = questions.save(Q1);
+		Question saveQ2 = questions.save(Q2);
 
 		assertThat(questions.findByTitleContainingOrderByIdDesc("title").get(0)).isEqualTo(
-			questions.findById(2L).get());
+			questions.findById(saveQ2.getId()).get());
 	}
 
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByDeletedFalse)")
 	void use_written_method_findByDeletedFalse() {
-		User JAVAJIGI = makeJavajigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+		questions.deleteAll();
+		questions.flush();
+		users.deleteAll();
+		users.flush();
 
-		users.save(JAVAJIGI);
+		User JAVAJIGI = makeJavajigi();
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Q1.setDeleted(true);
 		questions.save(Q1);
 		assertThat(questions.findByDeletedFalse().size()).isEqualTo(0);
@@ -109,21 +108,21 @@ public class QuestionTest {
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
 		User JAVAJIGI = makeJavajigi();
-		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
-
-		users.save(JAVAJIGI);
+		User saveJavajigi = users.save(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Question saveQ1 = questions.save(Q1);
+
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId())).isEqualTo(questions.findById(saveQ1.getId()));
 
 		saveQ1.setDeleted(true);
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId()).isPresent()).isFalse();
 	}
 
-	private User makeSanjigi() {
-		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-	}
-
 	private User makeJavajigi() {
 		return new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+	}
+
+	private User makeSanjigi() {
+		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
 	}
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -18,10 +18,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("연관관계 제거")
 	void delete_writer() {
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
+		Question saveQ1 = saveQ1(saveJavajigi());
 
 		Question expected = questions.findById(saveQ1.getId()).get();
 		expected.setWriter(null);
@@ -32,14 +29,8 @@ public class QuestionTest {
 	@Test
 	@DisplayName("작성자 업데이트 확인")
 	void update_writer() {
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
-
-		User SANJIGI = makeSanjigi();
-		User saveSanjigi = users.save(SANJIGI);
-		saveQ1.setWriter(saveSanjigi);
+		Question saveQ1 = saveQ1(saveJavajigi());
+		saveQ1.setWriter(saveSanjigi());
 
 		Question expected = questions.findById(saveQ1.getId()).get();
 
@@ -49,7 +40,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("user 를 만들지 않고 question 을 넣으면 에러 발생")
 	void fk_error() {
-		User JAVAJIGI = makeJavajigi();
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
 		assertThatThrownBy(() -> questions.save(Q1)).isInstanceOf(RuntimeException.class);
@@ -58,10 +49,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("질문을 조회하고 해당 질문의 작성자를 조회함")
 	void select_not_deleted_question_with_writer() {
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
+		Question saveQ1 = saveQ1(saveJavajigi());
 
 		Question question = questions.findByIdAndDeletedFalse(saveQ1.getId()).get();
 
@@ -71,15 +59,8 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByTitleContainingOrderByIdDesc)")
 	void select_start_with_order_by_id_desc() {
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
-		User SANJIGI = makeSanjigi();
-		User saveSanjigi = users.save(SANJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question Q2 = new Question("title2", "contents2").writtenBy(saveSanjigi);
-
-		Question saveQ1 = questions.save(Q1);
-		Question saveQ2 = questions.save(Q2);
+		Question saveQ1 = saveQ1(saveJavajigi());
+		Question saveQ2 = saveQ2(saveSanjigi());
 
 		assertThat(questions.findByTitleContainingOrderByIdDesc("title").get(0)).isEqualTo(
 			questions.findById(saveQ2.getId()).get());
@@ -88,13 +69,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByDeletedFalse)")
 	void use_written_method_findByDeletedFalse() {
-		questions.deleteAll();
-		questions.flush();
-		users.deleteAll();
-		users.flush();
-
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
+		User saveJavajigi = saveJavajigi();
 		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
 		Q1.setDeleted(true);
 		questions.save(Q1);
@@ -107,10 +82,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
-		User JAVAJIGI = makeJavajigi();
-		User saveJavajigi = users.save(JAVAJIGI);
-		Question Q1 = new Question("title1", "contents1").writtenBy(saveJavajigi);
-		Question saveQ1 = questions.save(Q1);
+		Question saveQ1 = saveQ1(saveJavajigi());
 
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId())).isEqualTo(questions.findById(saveQ1.getId()));
 
@@ -118,11 +90,23 @@ public class QuestionTest {
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId()).isPresent()).isFalse();
 	}
 
-	private User makeJavajigi() {
-		return new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+	private User saveJavajigi() {
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		return users.save(JAVAJIGI);
 	}
 
-	private User makeSanjigi() {
-		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+	private User saveSanjigi() {
+		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+		return users.save(SANJIGI);
+	}
+
+	private Question saveQ1(User user) {
+		Question Q1 = new Question("title1", "contents1").writtenBy(user);
+		return questions.save(Q1);
+	}
+
+	private Question saveQ2(User user) {
+		Question Q2 = new Question("title2", "contents2").writtenBy(user);
+		return questions.save(Q2);
 	}
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -16,6 +16,20 @@ public class QuestionTest {
 	UserRepository users;
 
 	@Test
+	@DisplayName("질문을 조회하고 해당 질문의 작성자를 조회함")
+	void select_not_deleted_question_with_writer() {
+		User JAVAJIGI = makeJavajigi();
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+
+		users.save(JAVAJIGI);
+		Question saveQ1 = questions.save(Q1);
+
+		Question question = questions.findByIdAndDeletedFalse(saveQ1.getId()).get();
+
+		assertThat(question.getWriter().getUserId()).isEqualTo("javajigi");
+	}
+
+	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByTitleContainingOrderByIdDesc)")
 	void select_start_with_order_by_id_desc() {
 		User JAVAJIGI = makeJavajigi();

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -18,8 +18,8 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByTitleContainingOrderByIdDesc)")
 	void select_start_with_order_by_id_desc() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+		User JAVAJIGI = makeJavajigi();
+		User SANJIGI = makeSanjigi();
 		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 		Question Q2 = new Question("title2", "contents2").writtenBy(SANJIGI);
 
@@ -35,7 +35,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByDeletedFalse)")
 	void use_written_method_findByDeletedFalse() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		User JAVAJIGI = makeJavajigi();
 		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
 		users.save(JAVAJIGI);
@@ -50,7 +50,7 @@ public class QuestionTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByIdAndDeletedFalse)")
 	void use_written_method_findByIdAndDeletedFalse() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		User JAVAJIGI = makeJavajigi();
 		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
 		users.save(JAVAJIGI);
@@ -59,5 +59,13 @@ public class QuestionTest {
 
 		saveQ1.setDeleted(true);
 		assertThat(questions.findByIdAndDeletedFalse(saveQ1.getId()).isPresent()).isFalse();
+	}
+
+	private User makeSanjigi() {
+		return new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+	}
+
+	private User makeJavajigi() {
+		return new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 	}
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -16,6 +16,15 @@ public class QuestionTest {
 	UserRepository users;
 
 	@Test
+	@DisplayName("user 를 만들지 않고 question 을 넣으면 에러 발생")
+	void fk_error() {
+		User JAVAJIGI = makeJavajigi();
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
+
+		assertThatThrownBy(() -> questions.save(Q1)).isInstanceOf(RuntimeException.class);
+	}
+
+	@Test
 	@DisplayName("질문을 조회하고 해당 질문의 작성자를 조회함")
 	void select_not_deleted_question_with_writer() {
 		User JAVAJIGI = makeJavajigi();

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -23,18 +23,6 @@ public class UserTest {
 		assertThat((String)users.findByEmail("javajigi").get(0)[0]).isEqualTo("javajigi");
 	}
 
-	@Test
-	@DisplayName("jpa 작성 메소드 사용(findByUserId)")
-	void use_written_method_findByUserId() {
-		User saveA1 = saveJavajigi();
-		User saveA2 = saveSanjigi();
-
-		assertThat(users.findByUserId(saveA1.getUserId()).get()).isEqualTo(
-			users.findById(saveA1.getId()).get());
-		assertThat(users.findByUserId(saveA2.getUserId()).get()).isEqualTo(
-			users.findById(saveA2.getId()).get());
-	}
-
 	private User saveJavajigi() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		return users.save(JAVAJIGI);

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -15,11 +15,8 @@ public class UserTest {
 	@Test
 	@DisplayName("jpql 사용)")
 	void select_name_by_email_using_jpql() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-
-		User saveA1 = users.save(JAVAJIGI);
-		User saveA2 = users.save(SANJIGI);
+		User saveA1 = saveJavajigi();
+		User saveA2 = saveSanjigi();
 
 		users.findByEmail("javajigi");
 
@@ -29,15 +26,22 @@ public class UserTest {
 	@Test
 	@DisplayName("jpa 작성 메소드 사용(findByUserId)")
 	void use_written_method_findByUserId() {
-		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-
-		User saveA1 = users.save(JAVAJIGI);
-		User saveA2 = users.save(SANJIGI);
+		User saveA1 = saveJavajigi();
+		User saveA2 = saveSanjigi();
 
 		assertThat(users.findByUserId(saveA1.getUserId()).get()).isEqualTo(
 			users.findById(saveA1.getId()).get());
 		assertThat(users.findByUserId(saveA2.getUserId()).get()).isEqualTo(
 			users.findById(saveA2.getId()).get());
+	}
+
+	private User saveJavajigi() {
+		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+		return users.save(JAVAJIGI);
+	}
+
+	private User saveSanjigi() {
+		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+		return users.save(SANJIGI);
 	}
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -40,7 +40,7 @@ class QnaServiceTest {
 	@Test
 	public void delete_성공() throws Exception {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+		Question question = new Question(1L, "title1", "contents1").writtenBy(JAVAJIGI);
 		Answer answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
 		question.addAnswer(answer);
 
@@ -58,7 +58,7 @@ class QnaServiceTest {
 	public void delete_다른_사람이_쓴_글() throws Exception {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+		Question question = new Question(1L, "title1", "contents1").writtenBy(JAVAJIGI);
 		Answer answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
 		question.addAnswer(answer);
 
@@ -71,7 +71,7 @@ class QnaServiceTest {
 	@Test
 	public void delete_성공_질문자_답변자_같음() throws Exception {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+		Question question = new Question(1L, "title1", "contents1").writtenBy(JAVAJIGI);
 		Answer answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
 		question.addAnswer(answer);
 
@@ -89,10 +89,10 @@ class QnaServiceTest {
 	public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
 		User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-		Question question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+		Question question = new Question(1L, "title1", "contents1").writtenBy(JAVAJIGI);
 		Answer answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
 		question.addAnswer(answer);
-		Question Q1 = new Question("title1", "contents1").writeBy(JAVAJIGI);
+		Question Q1 = new Question("title1", "contents1").writtenBy(JAVAJIGI);
 
 		Answer answer2 = new Answer(2L, SANJIGI, Q1, "Answers Contents1");
 		question.addAnswer(answer2);
@@ -107,7 +107,7 @@ class QnaServiceTest {
 
 	private void verifyDeleteHistories() {
 		User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-		Question question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+		Question question = new Question(1L, "title1", "contents1").writtenBy(JAVAJIGI);
 		Answer answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
 		question.addAnswer(answer);
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -112,8 +112,8 @@ class QnaServiceTest {
 		question.addAnswer(answer);
 
 		List<DeleteHistory> deleteHistories = Arrays.asList(
-			new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-			new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+			new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+			new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
 		);
 		verify(deleteHistoryService).saveAll(deleteHistories);
 	}


### PR DESCRIPTION
### Description
스텝 2연관 관계 매핑 입니다. 도메인의 엔티티 클래스마다 외래키 기준으로 관계를 매핑해줍니다.

작업 중 의미 없어 보이는 setter는 삭제하는 등의 리펙토링 작업을 진행해봤습니다. 로직을 수행하는데는 문제 없지만, 해당 설계가 좋은 설계인지는 아직 모르겠습니다..ㅠ 
도메인의 엔티티 클래스는 모두 다대일(ManyToOne) 단방향으로 설계하였습니다. 의미상으로 유저가 N개의 글을 작성할 수 있고, 질문에는 N개의 답변을 달 수 있기 때문에 ManyToOne으로 하였고, 현재 설계에서 로직 구현에 특별히 이슈가 없어 양방향 설정을 하지 않았습니다.

개발 진행 중 궁금한 사항이 생겨 하기와 같이 질문 드립니다.

1. 일대다 관계에서, OneToMany 단방향의 경우 문제가 발생할 소지가 있어 보통 양방향으로 설계를 추천하고는 합니다. 그러면 일대다 관계에서 ManyToOne 단방향으로 발생할 수 있는 이슈가 어떤 점이 있는지 궁금합니다. 진행 중 생각을 해보았으나, 이 경우 특별한 이슈는 없어 보이네요. 혹시 jpa 적용 중에 관련하여 이슈가 있었던 점이 있으셨는지 문의 드립니다.
2. 코드 내에 setter 가 많으면 해당 객체가 불변객체가 아니기 때문에 유지 보수가 어려워 질 수 있습니다. 그런데 jpa 에서는 보통 setter 를 통해 업데이트를 해주는데 서로 가치 충돌하는 부분이 있는 것 같습니다. 그래서 생각해봤는데, 엔티티의 각 필드마다 setter를 추가할 것이 아니라, 키값이되는 id를 제외하고 모든 필드값을 새로운 객체의 값을 받는식의 setter를 하나만 추가해주는 것은 설계적인 측면에서 봤을 때 어떤지 궁금합니다.
 - setter 가 필드마다 있는 경우 
![image](https://user-images.githubusercontent.com/81790362/121034864-54901180-c7e8-11eb-8434-84742d017220.png)

 - setter 가 한개만 있는 경우
![image](https://user-images.githubusercontent.com/81790362/121034985-6f628600-c7e8-11eb-9fc9-cfc6bf11edb6.png)

내용 확인 부탁드립니다. 감사합니다 : )