### PR TITLE
2단계 - 연관 관계 매핑

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -2,7 +2,6 @@ package qna.domain;
 
 import java.util.Objects;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -30,12 +29,12 @@ public class Answer extends BaseEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
     private User writer;
 
     public Answer(User writer, Question question, String contents) {
@@ -93,14 +92,4 @@ public class Answer extends BaseEntity {
         return writer;
     }
 
-    @Override
-    public String toString() {
-        return "Answer{" +
-            "id=" + id +
-            ", contents='" + contents + '\'' +
-            ", deleted=" + deleted +
-            ", question=" + question +
-            ", writer=" + writer +
-            '}';
-    }
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -9,13 +8,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
-import javax.persistence.Table;
 
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 @Entity
 public class Answer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column
     @Lob
@@ -53,6 +54,10 @@ public class Answer extends BaseEntity {
     protected Answer() {
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public boolean isOwner(User writer) {
         return this.writerId.equals(writer.getId());
     }
@@ -65,24 +70,12 @@ public class Answer extends BaseEntity {
         return writerId;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
-
     public Long getQuestionId() {
         return questionId;
     }
 
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
-    }
-
     public String getContents() {
         return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -2,12 +2,17 @@ package qna.domain;
 
 import java.util.Objects;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
@@ -25,11 +30,13 @@ public class Answer extends BaseEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
-    @Column
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
 
-    @Column
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -46,8 +53,8 @@ public class Answer extends BaseEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
@@ -59,19 +66,15 @@ public class Answer extends BaseEntity {
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
-    public void toQuestion(Question question) {
-        this.questionId = question.getId();
+    public void setQuestion(Question question) {
+        this.question = question;
     }
 
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public Long getQuestionId() {
-        return questionId;
+    public Question getQuestion() {
+        return question;
     }
 
     public String getContents() {
@@ -86,13 +89,18 @@ public class Answer extends BaseEntity {
         this.deleted = deleted;
     }
 
+    public User getWriter() {
+        return writer;
+    }
+
     @Override
     public String toString() {
         return "Answer{" +
-            "contents='" + contents + '\'' +
+            "id=" + id +
+            ", contents='" + contents + '\'' +
             ", deleted=" + deleted +
-            ", questionId=" + questionId +
-            ", writerId=" + writerId +
+            ", question=" + question +
+            ", writer=" + writer +
             '}';
     }
 }

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -1,9 +1,9 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -12,7 +12,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     Answer findByWriterId(Long id);
 
-    List<Answer> findByQuestionId(Long id);
+    List<Answer> findByQuestion(Question question);
 
     Answer findByContentsLike(String contents);
 }

--- a/src/main/java/qna/domain/BaseEntity.java
+++ b/src/main/java/qna/domain/BaseEntity.java
@@ -3,9 +3,6 @@ package qna.domain;
 import java.time.LocalDateTime;
 
 import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -16,18 +13,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    protected Long id;
-
     @CreatedDate
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
-
-    public Long getId() {
-        return id;
-    }
 
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -3,7 +3,6 @@ package qna.domain;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -36,8 +35,8 @@ public class DeleteHistory {
     @CreatedDate
     private LocalDateTime createDate;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
     private User deletedBy;
 
     public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
@@ -67,14 +66,4 @@ public class DeleteHistory {
         return Objects.hash(id, contentId, contentType, createDate, deletedBy);
     }
 
-    @Override
-    public String toString() {
-        return "DeleteHistory{" +
-            "id=" + id +
-            ", contentId=" + contentId +
-            ", contentType=" + contentType +
-            ", createDate=" + createDate +
-            ", deleter=" + deletedBy +
-            '}';
-    }
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -3,16 +3,20 @@ package qna.domain;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
-import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -32,13 +36,14 @@ public class DeleteHistory {
     @CreatedDate
     private LocalDateTime createDate;
 
-    @Column
-    private Long deletedById;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -52,15 +57,14 @@ public class DeleteHistory {
         if (o == null || getClass() != o.getClass())
             return false;
         DeleteHistory that = (DeleteHistory)o;
-        return Objects.equals(id, that.id) &&
-            contentType == that.contentType &&
-            Objects.equals(contentId, that.contentId) &&
-            Objects.equals(deletedById, that.deletedById);
+        return Objects.equals(id, that.id) && Objects.equals(contentId, that.contentId)
+            && contentType == that.contentType && Objects.equals(createDate, that.createDate)
+            && Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentId, contentType, createDate, deletedBy);
     }
 
     @Override
@@ -70,7 +74,7 @@ public class DeleteHistory {
             ", contentId=" + contentId +
             ", contentType=" + contentType +
             ", createDate=" + createDate +
-            ", deletedById=" + deletedById +
+            ", deleter=" + deletedBy +
             '}';
     }
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -5,15 +5,18 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
+import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 public class DeleteHistory {
     @Id

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -2,12 +2,17 @@ package qna.domain;
 
 import java.util.Objects;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Question extends BaseEntity {
@@ -25,8 +30,9 @@ public class Question extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
 
     protected Question() {
     }
@@ -42,16 +48,16 @@ public class Question extends BaseEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
-        answer.toQuestion(this);
+        answer.setQuestion(this);
     }
 
     public Long getId() {
@@ -62,10 +68,6 @@ public class Question extends BaseEntity {
         return title;
     }
 
-    public Long getWriterId() {
-        return writerId;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
@@ -74,14 +76,8 @@ public class Question extends BaseEntity {
         this.deleted = deleted;
     }
 
-    @Override
-    public String toString() {
-        return "Question{" +
-            "contents='" + contents + '\'' +
-            ", deleted=" + deleted +
-            ", title='" + title + '\'' +
-            ", writerId=" + writerId +
-            '}';
+    public User getWriter() {
+        return writer;
     }
 
     @Override
@@ -91,12 +87,13 @@ public class Question extends BaseEntity {
         if (o == null || getClass() != o.getClass())
             return false;
         Question question = (Question)o;
-        return deleted == question.deleted && Objects.equals(contents, question.contents)
-            && Objects.equals(title, question.title) && Objects.equals(writerId, question.writerId);
+        return deleted == question.deleted && Objects.equals(id, question.id) && Objects.equals(
+            contents, question.contents) && Objects.equals(title, question.title) && Objects.equals(
+            writer, question.writer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contents, deleted, title, writerId);
+        return Objects.hash(id, contents, deleted, title, writer);
     }
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -2,7 +2,6 @@ package qna.domain;
 
 import java.util.Objects;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -30,8 +29,8 @@ public class Question extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
     protected Question() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -11,7 +10,10 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 
 @Entity
-public class Question extends BaseEntity{
+public class Question extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column
     @Lob
@@ -52,28 +54,16 @@ public class Question extends BaseEntity{
         answer.toQuestion(this);
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getTitle() {
         return title;
     }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
-
     public Long getWriterId() {
         return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/QuestionRepository.java
+++ b/src/main/java/qna/domain/QuestionRepository.java
@@ -1,9 +1,9 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByDeletedFalse();

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,8 +1,5 @@
 package qna.domain;
 
-import qna.UnAuthorizedException;
-
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -10,11 +7,16 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Table;
+
+import qna.UnAuthorizedException;
 
 @Entity
-public class User extends BaseEntity{
+public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(length = 50)
     private String email;
@@ -77,36 +79,16 @@ public class User extends BaseEntity{
         return false;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getUserId() {
         return userId;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
     public String getPassword() {
         return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -15,7 +15,6 @@ public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 50)
@@ -91,6 +90,13 @@ public class User extends BaseEntity {
         return password;
     }
 
+    private static class GuestUser extends User {
+        @Override
+        public boolean isGuestUser() {
+            return true;
+        }
+    }
+
     @Override
     public String toString() {
         return "User{" +
@@ -101,10 +107,20 @@ public class User extends BaseEntity {
             '}';
     }
 
-    private static class GuestUser extends User {
-        @Override
-        public boolean isGuestUser() {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
             return true;
-        }
+        if (o == null || getClass() != o.getClass())
+            return false;
+        User user = (User)o;
+        return Objects.equals(id, user.id) && Objects.equals(email, user.email)
+            && Objects.equals(name, user.name) && Objects.equals(password, user.password)
+            && Objects.equals(userId, user.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, email, name, password, userId);
     }
 }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -4,8 +4,6 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 import qna.UnAuthorizedException;
@@ -95,16 +93,6 @@ public class User extends BaseEntity {
         public boolean isGuestUser() {
             return true;
         }
-    }
-
-    @Override
-    public String toString() {
-        return "User{" +
-            "email='" + email + '\'' +
-            ", name='" + name + '\'' +
-            ", password='" + password + '\'' +
-            ", userId='" + userId + '\'' +
-            '}';
     }
 
     @Override

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -1,8 +1,8 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -1,16 +1,23 @@
 package qna.service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import qna.domain.Answer;
+import qna.domain.AnswerRepository;
+import qna.domain.ContentType;
+import qna.domain.DeleteHistory;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
 
 @Service
 public class QnaService {
@@ -48,10 +55,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,28 +12,45 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 public class AnswerTest {
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
 
     @Autowired
     private AnswerRepository answers;
+    @Autowired
+    private UserRepository users;
+    @Autowired
+    private QuestionRepository questions;
+
+    private Answer firstAnswer;
+    private Answer secondAnswer;
+
+    @BeforeEach
+    void setUp() {
+        User firstUser = users.save(UserTest.JAVAJIGI);
+        User secondUser = users.save(UserTest.SANJIGI);
+
+        Question firstQuestion = questions.save(QuestionTest.Q1);
+        Question secondQuestion = questions.save(QuestionTest.Q2);
+
+        firstAnswer = new Answer(firstUser, firstQuestion, "Answers Contents1");
+        secondAnswer = new Answer(secondUser, secondQuestion, "Answers Contents2");
+    }
 
     @DisplayName("A1 Answer 정보 저장 및 데이터 확인")
     @Test
     void saveAnswer() {
-        final Answer actual = answers.save(A1);
+        final Answer actual = answers.save(firstAnswer);
 
         User writer = actual.getWriter();
         Question question = actual.getQuestion();
 
-        assertThat(writer).isEqualTo(A1.getWriter());
-        assertThat(question).isEqualTo(A1.getQuestion());
+        assertThat(writer).isEqualTo(firstAnswer.getWriter());
+        assertThat(question).isEqualTo(firstAnswer.getQuestion());
     }
 
     @DisplayName("writer_id로 데이터 조회")
     @Test
     void findByWriterId() {
-        final Answer standard = answers.save(A1);
+        final Answer standard = answers.save(firstAnswer);
         final Answer target = answers.findByWriterId(UserTest.JAVAJIGI.getId());
 
         User standardWriter = standard.getWriter();
@@ -44,8 +62,8 @@ public class AnswerTest {
     @DisplayName("QuestionId로 데이터 조회")
     @Test
     void findByQuestionId() {
-        final Answer standard = answers.save(A1);
-        final List<Answer> target = answers.findByQuestionId(QuestionTest.Q1.getId());
+        final Answer standard = answers.save(firstAnswer);
+        final List<Answer> target = answers.findByQuestion(firstAnswer.getQuestion());
 
         assertThat(target).contains(standard);
     }
@@ -53,8 +71,8 @@ public class AnswerTest {
     @DisplayName("Id 와 Deleted 값이 fasle 인 값 찾기")
     @Test
     void findByIdAndDeletedFalse() {
-        answers.save(A2);
-        final Answer target = answers.findByIdAndDeletedFalse(A2.getId()).get();
+        answers.save(secondAnswer);
+        final Answer target = answers.findByIdAndDeletedFalse(secondAnswer.getId()).get();
 
         boolean targetDeleted = target.isDeleted();
 
@@ -64,7 +82,7 @@ public class AnswerTest {
     @DisplayName("Contents 값 'ents1' Like 찾기")
     @Test
     void findByContentsLike() {
-        answers.save(A1);
+        answers.save(firstAnswer);
         final Answer target = answers.findByContentsLike("%ents1%");
 
         String targetContents = target.getContents();

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -22,11 +22,11 @@ public class AnswerTest {
     void saveAnswer() {
         final Answer actual = answers.save(A1);
 
-        Long writerId = actual.getWriterId();
-        Long questionId = actual.getQuestionId();
+        User writer = actual.getWriter();
+        Question question = actual.getQuestion();
 
-        assertThat(writerId).isEqualTo(A1.getWriterId());
-        assertThat(questionId).isEqualTo(A1.getQuestionId());
+        assertThat(writer).isEqualTo(A1.getWriter());
+        assertThat(question).isEqualTo(A1.getQuestion());
     }
 
     @DisplayName("writer_id로 데이터 조회")
@@ -35,10 +35,10 @@ public class AnswerTest {
         final Answer standard = answers.save(A1);
         final Answer target = answers.findByWriterId(UserTest.JAVAJIGI.getId());
 
-        Long standardWriterId = standard.getWriterId();
-        Long targetWriterId = target.getWriterId();
+        User standardWriter = standard.getWriter();
+        User targetWriter = target.getWriter();
 
-        assertThat(standardWriterId).isEqualTo(targetWriterId);
+        assertThat(standardWriter).isEqualTo(targetWriter);
     }
 
     @DisplayName("QuestionId로 데이터 조회")

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,18 @@
+package qna.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class DeleteHistoryTest {
+
+    @Autowired
+    DeleteHistoryRepository deleteHistorys;
+
+    @Test
+    void init() {
+        DeleteHistory d = new DeleteHistory();
+        deleteHistorys.save(d);
+    }
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -22,9 +22,9 @@ public class QuestionTest {
     void saveQuestion() {
         final Question actual = questions.save(Q1);
 
-        Long writerId = actual.getWriterId();
+        User writerId = actual.getWriter();
 
-        assertThat(writerId).isEqualTo(Q1.getWriterId());
+        assertThat(writerId).isEqualTo(Q1.getWriter());
     }
 
     @DisplayName("writer_id로 Question 정보 찾기")
@@ -33,10 +33,10 @@ public class QuestionTest {
         final Question standard = questions.save(Q1);
         final Question target = questions.findByWriterId(UserTest.JAVAJIGI.getId());
 
-        Long standardWriterId = standard.getWriterId();
-        Long targetWriterId = target.getWriterId();
+        User standardWriter = standard.getWriter();
+        User targetWriter = target.getWriter();
 
-        assertThat(standardWriterId).isEqualTo(targetWriterId);
+        assertThat(standardWriter).isEqualTo(targetWriter);
     }
 
     @DisplayName("Question Title 정보 Like로 찾기")

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,15 @@ public class QuestionTest {
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
 
     @Autowired
+    private UserRepository users;
+    @Autowired
     private QuestionRepository questions;
+
+    @BeforeEach
+    void setUp() {
+        users.save(UserTest.SANJIGI);
+        users.save(UserTest.JAVAJIGI);
+    }
 
     @DisplayName("Question 저장 및 데이터 확인")
     @Test
@@ -53,11 +62,11 @@ public class QuestionTest {
     @DisplayName("Question 정보 중 deleted false 인 값 찾기")
     @Test
     void findByDeletedFalse() {
-        questions.save(Q1);
-        questions.save(Q2);
+        Question firstQuestion = questions.save(Q1);
+        Question secondQuestion = questions.save(Q2);
 
         List<Question> questionList = questions.findByDeletedFalse();
 
-        assertThat(questionList).contains(Q1, Q2);
+        assertThat(questionList).contains(firstQuestion, secondQuestion);
     }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -31,7 +31,7 @@ public class UserTest {
     @Test
     void findByUserId() {
         final User standard = users.save(JAVAJIGI);
-        final User target = users.findByUserId(JAVAJIGI.getUserId()).get();
+        final User target = users.findByUserId(standard.getUserId()).get();
 
         String standardUserId = standard.getUserId();
         String targetUserId = target.getUserId();
@@ -43,7 +43,7 @@ public class UserTest {
     @Test
     void findByUserIdAndPassword() {
         final User standard = users.save(JAVAJIGI);
-        final User target = users.findByUserIdAndPassword(JAVAJIGI.getUserId(), JAVAJIGI.getPassword());
+        final User target = users.findByUserIdAndPassword(standard.getUserId(), standard.getPassword());
 
         Long standardId = standard.getId();
         Long targetId = target.getId();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
안녕하세요 리뷰어님 ! 지난 피드백 감사드립니다!

연관 관계 매핑을 하며 테이블은 예시와는 같게 나오는데 테스트에서 오류가 계속 발생을 했습니다.  😢 
1. `Referential integrity constraint violation` 오류가 발생을 하여 찾아보니 두 Entity간 부모, 자식 관계가 맺어졌지만 각 클래스에 `@GeneratedValue`를 설정하여 각각에 시퀀스 값이 들어가게 되어 `FK` 제약조건이 걸려 오류가 났다고 해서 `User Entity`의 `@GeneratedValue`를 삭제를 하였는데 맞게 진행을 한건지 궁금합니다. 다른 해결 방법이 있을까요 ?.. 

2. 참조되는 객체가 생성되지 않아  `save the transient instance before flushing` 오류가 발생하였는데 테스트를 진행할 때 참조되는 객체를 생성하고 테스트를 진행하게 해야 하는 것인가요? 현재는 `CascadeType.PERSIST`가 엔티티를 영속화 할때 참조된 엔티티도 영속화 시켜주는 기능이라고 해서 사용을 하였는데.. 맞게 이해한지 모르겠네요 .. 

3.  위의 내용으로 문제를 해결하고 보니 개별테스트는 통과를 하는데 전체 테스트할때에는 `detached entity passed to persist` 오류가 발생을 하네요 ... 같은 객체를 참조하고 있는 서로 다른 두 객체를 `persist`할 때 발생을 한다고 하는데 `Cascade`를 없애자니 `save the transient instance before flushing`  오류가 발생을 해서 함정에 빠진 기분이었습니다.. 제가 잘못생각하는 부분이 어디일까요?.. 

고민하고 찾아보다가 해결이 안되서 리뷰 요청드립니다 😭 
감사합니다 ! 

---

피드백 감사드립니다 !!! 이해하는데 큰도움 되었습니다 !! 

질문 하나만 더 드리겠습니다 ! 
1.  `findBy` 해서 데이터를 찾을 때 `FK`의 경우 객체로 조회를 하는게 맞는지 객체의 `ID` 값으로 조회를 하는게 맞는지 궁금 합니다. 두개 다 동작을 해서 여쭤봅니다 ! 
ex ) `findByQuestionId` vs `findByQuestion` 

리뷰 재요청 드립니다 !!

