### PR TITLE
🚀 2단계 - 연관 관계 매핑

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -8,7 +8,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.util.Objects;
 
@@ -20,18 +22,20 @@ public class Answer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "writer_id")
-    private Long writerId;
-
-    @Column(name = "question_id")
-    private Long questionId;
-
     @Lob
     @Column(name = "contents", columnDefinition = "LONGTEXT")
     private String contents;
 
     @Column(name = "deleted")
     private boolean deleted = false;
+
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private User writer;
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
 
     protected Answer() {
     }
@@ -51,17 +55,18 @@ public class Answer {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
+        question.getAnswers().add(this);
     }
 
     public Long getId() {
@@ -70,22 +75,6 @@ public class Answer {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
-
-    public Long getQuestionId() {
-        return questionId;
-    }
-
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
     }
 
     public String getContents() {
@@ -104,14 +93,30 @@ public class Answer {
         this.deleted = deleted;
     }
 
+    public Question getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(Question question) {
+        this.question = question;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+    public void setWriter(User writer) {
+        this.writer = writer;
+    }
+
     @Override
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
+                ", writer=" + writer +
+                ", question=" + question +
                 '}';
     }
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -7,6 +7,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -26,20 +28,21 @@ public class DeleteHistory {
     @Column(name = "content_id")
     private Long contentId;
 
-    @Column(name = "deleted_by_id")
-    private Long deletedById;
-
     @Column(name = "create_date")
     private LocalDateTime createDate = LocalDateTime.now();
+
+    @ManyToOne
+    @JoinColumn(name = "deleted_by_id")
+    private User deletedByUser;
 
     protected DeleteHistory() {
 
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedByUser, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedByUser = deletedByUser;
         this.createDate = createDate;
     }
 
@@ -52,15 +55,13 @@ public class DeleteHistory {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DeleteHistory that = (DeleteHistory) o;
-        return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+        return Objects.equals(id, that.id) && contentType == that.contentType && Objects.equals(contentId, that.contentId) && Objects.equals(deletedByUser,
+                that.deletedByUser);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedByUser);
     }
 
     @Override
@@ -69,8 +70,8 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
                 ", createDate=" + createDate +
+                ", deletedByUser=" + deletedByUser +
                 '}';
     }
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -5,8 +5,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "question")
@@ -23,11 +28,16 @@ public class Question {
     @Column(name = "contents", columnDefinition = "LONGTEXT")
     private String contents;
 
-    @Column(name = "writer_id")
-    private Long writerId;
-
     @Column(name = "deleted")
     private boolean deleted = false;
+
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private User writer;
+
+    @OneToMany
+    @JoinColumn(name = "question_id")
+    private List<Answer> answers = new ArrayList<>();
 
     protected Question() {
     }
@@ -43,15 +53,16 @@ public class Question {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
+        answers.add(answer);
         answer.toQuestion(this);
     }
 
@@ -79,14 +90,6 @@ public class Question {
         this.contents = contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
@@ -95,14 +98,19 @@ public class Question {
         this.deleted = deleted;
     }
 
-    @Override
-    public String toString() {
-        return "Question{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
-                ", deleted=" + deleted +
-                '}';
+    public User getWriter() {
+        return writer;
+    }
+
+    public void setWriter(User writer) {
+        this.writer = writer;
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+
+    public void setAnswers(List<Answer> answers) {
+        this.answers = answers;
     }
 }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -7,7 +7,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -31,6 +35,18 @@ public class User {
 
     @Column(name = "email")
     private String email;
+
+    @OneToMany
+    @JoinColumn(name = "writer_id")
+    private List<Answer> answers = new ArrayList<>();
+
+    @OneToMany
+    @JoinColumn(name = "deleted_by_id")
+    private List<DeleteHistory> deleteHistories = new ArrayList<>();
+
+    @OneToMany
+    @JoinColumn(name = "writer_id")
+    private List<Question> questions = new ArrayList<>();
 
     protected User() {
     }
@@ -121,15 +137,28 @@ public class User {
         this.email = email;
     }
 
-    @Override
-    public String toString() {
-        return "User{" +
-                "id=" + id +
-                ", userId='" + userId + '\'' +
-                ", password='" + password + '\'' +
-                ", name='" + name + '\'' +
-                ", email='" + email + '\'' +
-                '}';
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+
+    public void setAnswers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return deleteHistories;
+    }
+
+    public void setDeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public List<Question> getQuestions() {
+        return questions;
+    }
+
+    public void setQuestions(List<Question> questions) {
+        this.questions = questions;
     }
 
     private static class GuestUser extends User {

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, loginUser, LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), loginUser, LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/subway/Line.java
+++ b/src/main/java/qna/subway/Line.java
@@ -1,0 +1,22 @@
+package qna.subway;
+
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Line {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    protected Line() {
+    }
+}

--- a/src/main/java/qna/subway/Station.java
+++ b/src/main/java/qna/subway/Station.java
@@ -1,4 +1,5 @@
-package subway.domain;
+package qna.subway;
+
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -43,40 +44,5 @@ public class Station {
 
     protected Station() {
 
-    }
-
-    protected Station(Long id, String name) {
-        this(name);
-        this.id = id;
-    }
-
-    protected Station(String name) {
-        this.name = name;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void changeName(String name) {
-        this.name = name;
-    }
-
-    public void setLine(Line line) {
-
-//        if (Objects.nonNull(this.line)) {
-//            this.line.getStations().remove(this);
-//        }
-
-        this.line = line;
-        line.getStations().add(this);
-    }
-
-    public Line getLine() {
-        return this.line;
     }
 }

--- a/src/main/java/subway/domain/Favorite.java
+++ b/src/main/java/subway/domain/Favorite.java
@@ -1,0 +1,17 @@
+package subway.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Favorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    protected Favorite() {
+    }
+}

--- a/src/main/java/subway/domain/Favorite.java
+++ b/src/main/java/subway/domain/Favorite.java
@@ -4,6 +4,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Favorite {
@@ -11,6 +13,11 @@ public class Favorite {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     protected Favorite() {
     }

--- a/src/main/java/subway/domain/FavoriteRepository.java
+++ b/src/main/java/subway/domain/FavoriteRepository.java
@@ -1,0 +1,6 @@
+package subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/subway/domain/Member.java
+++ b/src/main/java/subway/domain/Member.java
@@ -1,0 +1,35 @@
+package subway.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    @OneToMany
+    @JoinColumn(name = "member_id")
+    private List<Favorite> favorites = new ArrayList<>();
+
+    protected Member() {
+
+    }
+
+    public Member(String name) {
+        this.name = name;
+    }
+
+    public void addFavorite(Favorite favorite) {
+        this.favorites.add(favorite);
+    }
+}

--- a/src/main/java/subway/domain/MemberRepository.java
+++ b/src/main/java/subway/domain/MemberRepository.java
@@ -1,0 +1,6 @@
+package subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/subway/domain/Station.java
+++ b/src/main/java/subway/domain/Station.java
@@ -73,7 +73,7 @@ public class Station {
 //        }
 
         this.line = line;
-        line.getStations().add(this);
+//        line.getStations().add(this);
     }
 
     public Line getLine() {

--- a/src/main/java/subway/domain/StationRepository.java
+++ b/src/main/java/subway/domain/StationRepository.java
@@ -3,5 +3,5 @@ package subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
-    Station findByName(String name);
+    Station findByName(String name); // 쿼리 메소드라고 한다.
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.h2.console.enabled=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:~/test;MODE=MySQL
 spring.datasource.username=sa
 spring.h2.console.enabled=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -46,11 +46,8 @@ public class AnswerRepositoryTest {
         Answer saved1 = answerRepository.save(answer1);
         Answer saved2 = answerRepository.save(answer2);
 
-        Answer find1 = answerRepository.findById(saved1.getId())
-                .orElse(new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, anyString()));
-
-        Answer find2 = answerRepository.findById(saved2.getId())
-                .orElse(new Answer(UserTest.SANJIGI, QuestionTest.Q2, anyString()));
+        Answer find1 = answerRepository.findById(saved1.getId()).orElse(null);
+        Answer find2 = answerRepository.findById(saved2.getId()).orElse(null);
 
         // then
         Assertions.assertThat(saved1).isEqualTo(find1);

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -2,6 +2,7 @@ package qna.repository;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -19,6 +20,7 @@ public class AnswerRepositoryTest {
     @Autowired
     private AnswerRepository answerRepository;
 
+    @DisplayName("Answer 데이터 save 하는 테스트 진행")
     @Test
     public void save() {
 
@@ -35,6 +37,7 @@ public class AnswerRepositoryTest {
         Assertions.assertThat(saved2).isEqualTo(answer2);
     }
 
+    @DisplayName("Answer 데이터 find 하는 테스트 진행")
     @Test
     public void find() {
 

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -10,6 +10,7 @@ import qna.domain.Answer;
 import qna.domain.AnswerRepository;
 import qna.domain.AnswerTest;
 import qna.domain.QuestionTest;
+import qna.domain.User;
 import qna.domain.UserTest;
 
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package qna.repository;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,6 +18,7 @@ public class DeleteHistoryRepositoryTest {
     @Autowired
     private DeleteHistoryRepository deleteHistoryRepository;
 
+    @DisplayName("DeleteHistory 데이터 save 하는 테스트 진행")
     @Test
     public void save() {
 
@@ -30,6 +32,7 @@ public class DeleteHistoryRepositoryTest {
         Assertions.assertThat(result).isEqualTo(deleteHistory);
     }
 
+    @DisplayName("DeleteHistory 데이터 find 하는 테스트 진행")
     @Test
     public void find() {
 

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import qna.domain.ContentType;
 import qna.domain.DeleteHistory;
 import qna.domain.DeleteHistoryRepository;
+import qna.domain.UserTest;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -23,7 +24,7 @@ public class DeleteHistoryRepositoryTest {
     public void save() {
 
         // given
-        DeleteHistory deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, 2L, LocalDateTime.of(2021, Month.AUGUST, 1, 10, 10));
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, UserTest.HONGHEE, LocalDateTime.of(2021, Month.AUGUST, 1, 10, 10));
 
         // when
         DeleteHistory result = deleteHistoryRepository.save(deleteHistory);
@@ -37,7 +38,7 @@ public class DeleteHistoryRepositoryTest {
     public void find() {
 
         // given
-        DeleteHistory deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, 2L, LocalDateTime.of(2021, Month.AUGUST, 1, 10, 10));
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.ANSWER, 1L, UserTest.HONGHEE, LocalDateTime.of(2021, Month.AUGUST, 1, 10, 10));
         DeleteHistory result = deleteHistoryRepository.save(deleteHistory);
 
         // when

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -1,6 +1,7 @@
 package qna.repository;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -14,6 +15,7 @@ public class QuestionRepositoryTest {
     @Autowired
     private QuestionRepository questionRepository;
 
+    @DisplayName("Question 데이터 save 하는 테스트 진행")
     @Test
     public void save() {
 
@@ -31,6 +33,7 @@ public class QuestionRepositoryTest {
 
     }
 
+    @DisplayName("Question 데이터 find 하는 테스트 진행")
     @Test
     public void find() {
 

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -1,6 +1,7 @@
 package qna.repository;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -14,6 +15,7 @@ public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
+    @DisplayName("User 데이터 save 하는 테스트 진행")
     @Test
     public void save() {
 
@@ -30,6 +32,7 @@ public class UserRepositoryTest {
         Assertions.assertThat(saved2).isEqualTo(user2);
     }
 
+    @DisplayName("User 데이터 find 하는 테스트 진행")
     @Test
     public void find() {
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -11,6 +11,7 @@ import qna.domain.*;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,7 +47,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Collections.singletonList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -89,8 +90,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/subway/domain/LineTest.java
+++ b/src/test/java/subway/domain/LineTest.java
@@ -44,7 +44,7 @@ public class LineTest {
     public void findByNameWithLine() {
         Station actual = stations.findByName("교대역");
         Assertions.assertThat(actual).isNotNull();
-        Assertions.assertThat(actual.getLine().getName()).isEqualTo("3호선");
+        Assertions.assertThat(actual.getLine().getName()).isEqualTo("2호선");
     }
 
     @Test
@@ -71,13 +71,9 @@ public class LineTest {
     public void save() {
         Line expected = new Line("2호선");
         expected.addStation(stations.save(new Station("잠실역")));
-        Assertions.assertThat(expected.getStations().size()).isEqualTo(1);
+        // Assertions.assertThat(expected.getStations().size()).isEqualTo(1);
 
         lines.save(expected);
         lines.flush();
-
-
-
-
     }
 }

--- a/src/test/java/subway/domain/LineTest.java
+++ b/src/test/java/subway/domain/LineTest.java
@@ -1,10 +1,10 @@
 package subway.domain;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 
 @DataJpaTest
 public class LineTest {
@@ -15,24 +15,30 @@ public class LineTest {
     @Autowired
     private StationRepository stations;
 
-    @BeforeEach
-    public void setUp() {
-        Line line = new Line("3호선");
-        Station station = new Station("교대역");
-        lines.save(line);
-        stations.save(station);
-    }
-
     @Test
     public void saveWithLine() {
         Station expected = new Station("잠실역");
         Line line = new Line("2호선");
-        expected.setLine(line);
-        line.addStation(expected);
-        lines.save(line);
-        Station actual = stations.save(expected);
-        stations.flush(); // commit
+
+        Assertions.assertThatThrownBy(() -> {
+                    expected.setLine(line);
+                    Station actual = stations.save(expected); // 해당 쿼리는 실패한다. 왜냐하면 Line 객체가 영속성 컨텍스트에 있지 않기 때문이다.
+                    stations.flush(); // commit 과 같은 것이라고 보면 된다.
+                }
+        ).isInstanceOf(InvalidDataAccessApiUsageException.class);
     }
+
+    @Test
+    public void saveWithLine_success() {
+        Station expected = new Station("잠실역");
+        Line line = new Line("2호선");
+
+        expected.setLine(lines.save(line)); // line 객체를 영속성 상태로 만든다.
+        Station actual = stations.save(expected);
+        stations.flush(); // commit 과 같은 것이라고 보면 된다.
+        //Assertions.assertThat(actual).isEqualTo(expected);
+    }
+
 
     @Test
     public void findByNameWithLine() {
@@ -51,13 +57,13 @@ public class LineTest {
     @Test
     public void removeLine() {
         Station station = stations.findByName("교대역");
-        station.setLine(null);
+        station.setLine(null); // 연관관계 제거
         stations.flush();
     }
 
     @Test
     public void findById() {
-        Line line = lines.findByName("3호선");
+        Line line = lines.findByName("2호선");
         Assertions.assertThat(line.getStations()).hasSize(1);
     }
 
@@ -65,6 +71,13 @@ public class LineTest {
     public void save() {
         Line expected = new Line("2호선");
         expected.addStation(stations.save(new Station("잠실역")));
+        Assertions.assertThat(expected.getStations().size()).isEqualTo(1);
+
         lines.save(expected);
+        lines.flush();
+
+
+
+
     }
 }

--- a/src/test/java/subway/domain/MemberTest.java
+++ b/src/test/java/subway/domain/MemberTest.java
@@ -1,0 +1,24 @@
+package subway.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class MemberTest {
+
+    @Autowired
+    private MemberRepository members;
+
+    @Autowired
+    private FavoriteRepository favorites;
+
+
+    @Test
+    public void save() {
+        Member member = new Member("jason");
+        member.addFavorite(favorites.save(new Favorite()));
+        Member actual = members.save(member);
+        members.flush();
+    }
+}

--- a/src/test/java/subway/domain/StationTest.java
+++ b/src/test/java/subway/domain/StationTest.java
@@ -13,8 +13,23 @@ public class StationTest {
 
     @Test
     public void save() {
+        // begin
         final Station station = new Station("잠실역");
         final Station actual = stations.save(station);
+        Assertions.assertThat(actual.getId()).isNotNull();
+        Assertions.assertThat(actual.getName()).isEqualTo("잠실역");
+        // commit
+        // 왜 commit 이 되기 전에 insert 쿼리가 먼저 나갔을까? -> 데이터베이스의 식별자 생성전략과 관련이 있다.
+        // Identity(Auto Increment) 는 식별자를 생성하기 위해서 DB를 한번 조회를 해야한다.
+        // 그래서 쓰기 지연과 관련 없이 데이터베이스에 저장을 하게 된다.
+        // 만약 Identity 가 아니라 식별자를 관리하는 테이블을 별도로 만든다면... 쓰기지연이 일어난다.
+    }
+
+    @Test
+    public void save_delay() {
+        // begin
+        final Station station = new Station(3L, "잠실역"); // @GeneratedValue(strategy = GenerationType.IDENTITY) 삭제하고 실행해볼 것
+        final Station actual = stations.save(station); // insert 가 아니라 select 쿼리로 나간다. -> id가 있으면 persist 가 아니라 merge 방식으로 동작
         Assertions.assertThat(actual.getId()).isNotNull();
         Assertions.assertThat(actual.getName()).isEqualTo("잠실역");
     }
@@ -26,8 +41,9 @@ public class StationTest {
 
         Assertions.assertThat(station2.getId()).isEqualTo(station1.getId());
         Assertions.assertThat(station2.getName()).isEqualTo(station1.getName());
-        Assertions.assertThat(station2).isEqualTo(station1);
-        Assertions.assertThat(station2).isSameAs(station1);
+
+        Assertions.assertThat(station2).isEqualTo(station1); // 동등성
+        Assertions.assertThat(station2).isSameAs(station1); // 동일성 - 주소값 비교
     }
 
     @Test
@@ -41,8 +57,8 @@ public class StationTest {
     public void update() {
         Station station1 = stations.save(new Station("잠실역"));
         station1.changeName("몽촌토성역");
-        station1.changeName("잠실역"); // 변화된 내용이 없어서 update 쿼리가 실행이 안된다.
+//        station1.changeName("잠실역"); // 변화된 내용이 없어서 update 쿼리가 실행이 안된다.
         Station station2 = stations.findByName("몽촌토성역");
-        Assertions.assertThat(station2).isNull();
+        Assertions.assertThat(station2).isNotNull();
     }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,6 @@
+insert into line (id, name)
+values (1, '2호선');
+
+insert
+into station(id, line_id, name)
+values (1, 1, '교대역');


### PR DESCRIPTION
안녕하세요? step1 단계를 진행하고 step2 까지 좀 오래 걸렸네요!
JPA에 대한 기본적인 지식이 부족하다고 생각해서 Jason님이 강의해주신 내용을 학습하고 과제를 진행하느라 조금 늦었습니다!

다름이 아니라 Jason님 강의를 들으면서 몇가지 궁금한 사항이 있었는데요!

1. JPA Hands-on Par2에서  `연관 관계 편의 메소드`에서 아래와 같이 setLine, addStation에서 양방향으로 설정을 하고있는데요.
```
public void setLine(Line line) {
    this.line = line;
    line.getStations().add(this);
}
```
```
public void addStation(Station station) {
    stations.add(station);
    station.setLine(this);
}
```
그런데 위와 같이 진행을 하면 addStation(Station station) 메소드를 호출한 순간 Line 클래스에 List<Station> 자료구조에 똑같은 데이터가 2개가 들어가는 것 같더라구요! 근데 실제로는 DB에는 영속성 컨텍스트에 같은 데이터로 간주해서 Stataion 테이블에 Insert는 한번만 되었습니다.
<img width="1034" alt="스크린샷 2021-11-21 오후 1 25 25" src="https://user-images.githubusercontent.com/17119607/142749596-fb00995b-febb-4866-b95f-95bed61a47b8.png">

이렇게 되는게 맞는걸까요?
<br/><br/><br/>

2. 그리고 바로 아래 `연관 관계 편의 메서드 작성 시 주의 사항` 에서 예제 코드가 아래와 같은데요.
```
public void setLine(Line line) {
    if (Objects.nonNull(this.line) {
        this.line.getStations().remove(this); // 만약 this.line 은 null이 아니지만, this.line.getStation()이 null이면 NullpointException 이 발생하는데 뭔가 방어코드라고 보기엔 조금 방어가 잘안되는 것 같았습니다.
    }
    this.line = line;
    line.getStations().add(this);
}
```
위 코드는 분명 StackOverFlow를 막기 위한 코드라고 짐작이 되는데, 한편으로는 NullPointException을 발생시킬 수 있는 코드라고 생각이되서요. 제가 잘못 이해한것일까요?!
<br/><br/><br/>

3. 그리고 마지막으로 `@ManyToOne` 과 `@OneToMany`에서 `@JoinColumn`  관련해서 질문 사항이 있는데요!
`Station`과 `Line` 은 다대일의 관계입니다. 그래서 Station클래스 입장에서
```
class Station {
    ...
    @ManyToOne
    @JoinColumn(name = "line_id")
    private Line line;
    ...
}
````
이렇게 @JoinColumn으로 명시적으로 컬럼 이름을 제시하고

```
class Line {
    ...
    @OneToMany
    @JoinColumn(name = "line")
    private List<Station> stations = new ArrayList<>();
    ...
}
```
위와 같이 @JoinColumn으로 외래키 관리자를 명시해서 사용하면, 좀 더 Station과 Line의 관계를 명확하게 표시해줄 수 있다는 생각이 들어서요.
보통 리뷰어님의 경우는 Station의 @JoinColumn을 생략해서 사용하시는지 궁금합니다!

뭔가 질문이 길었네요! 
답변과 코드에 대한 피드백을 주시면 정말 감사하겠습니다!

감사합니다.

