### PR TITLE
🚀 3단계 - 질문 삭제하기 리팩터링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -12,6 +13,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -69,20 +71,22 @@ public class Answer {
         question.getAnswers().add(this);
     }
 
+    public DeleteHistory deleteAnswer(User user) throws CannotDeleteException {
+
+        if (!this.writer.equals(user)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        this.deleted = true;
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+    }
+
     public Long getId() {
         return id;
     }
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
     }
 
     public boolean isDeleted() {
@@ -103,10 +107,6 @@ public class Answer {
 
     public User getWriter() {
         return writer;
-    }
-
-    public void setWriter(User writer) {
-        this.writer = writer;
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -78,7 +78,7 @@ public class Answer {
         }
 
         this.deleted = true;
-        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+        return DeleteHistory.ofAnswer(id, writer);
     }
 
     public Long getId() {

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -50,6 +50,14 @@ public class DeleteHistory {
         return id;
     }
 
+    public static DeleteHistory ofAnswer(Long answerId, User writer) {
+        return new DeleteHistory(ContentType.ANSWER, answerId, writer, LocalDateTime.now());
+    }
+
+    public static DeleteHistory ofQuestion(Long questionId, User writer) {
+        return new DeleteHistory(ContentType.QUESTION, questionId, writer, LocalDateTime.now());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -42,7 +42,7 @@ public class Question {
 
     @OneToMany
     @JoinColumn(name = "question_id")
-    private Set<Answer> answers = new HashSet<>();
+    private List<Answer> answers = new ArrayList<>();
 
     protected Question() {
     }
@@ -64,7 +64,7 @@ public class Question {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        deleteHistories.add(DeleteHistory.ofQuestion(id, writer));
         for (Answer answer : answers) {
             DeleteHistory deletedAnswer = answer.deleteAnswer(loginUser);
             deleteHistories.add(deletedAnswer);
@@ -84,7 +84,6 @@ public class Question {
     }
 
     public void addAnswer(Answer answer) {
-        answers.add(answer);
         answer.toQuestion(this);
     }
 
@@ -124,7 +123,7 @@ public class Question {
         return writer;
     }
 
-    public Set<Answer> getAnswers() {
+    public List<Answer> getAnswers() {
         return answers;
     }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -34,25 +34,8 @@ public class QnaService {
 
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
-        Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, loginUser, LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), loginUser, LocalDateTime.now()));
-        }
+        Question question = findQuestionById(questionId);  // read data from db - 연관관계 매핑으로 answers 도 같이 읽어올 수 있음
+        List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,8 +1,50 @@
 package qna.domain;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
 public class AnswerTest {
+
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
     public static final Answer A3 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Content3");
     public static final Answer A4 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents4");
+    public static final Answer A5 = new Answer(UserTest.HONGHEE, QuestionTest.Q5, "Answers Contents4");
+
+
+    @DisplayName("정상적으로 삭제가 되는 경우 테스트")
+    @Test
+    public void deleteAnswerTest() throws CannotDeleteException {
+
+        // when
+        User loginUser = UserTest.SANJIGI;
+        Answer answer = A2;
+
+        // then
+        DeleteHistory deleteHistory = answer.deleteAnswer(loginUser);
+
+        // given
+        Assertions.assertThat(answer.isDeleted()).isTrue();
+        Assertions.assertThat(deleteHistory).isNotNull();
+    }
+
+    @DisplayName("정상적으로 삭제되지 않는 경우 테스트")
+    @Test
+    public void deleteAnswerFailureTest() {
+
+        // when
+        User loginUser = UserTest.SANJIGI;
+        Answer answer = A1;
+
+        // then
+        Assertions.assertThatThrownBy(() -> {
+            DeleteHistory deleteHistory = answer.deleteAnswer(loginUser);
+            Assertions.assertThat(deleteHistory).isNull();
+        });
+
+        // given
+        Assertions.assertThat(answer.isDeleted()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,8 +1,90 @@
 package qna.domain;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.List;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
     public static final Question Q3 = new Question("title3", "contents3").writeBy(UserTest.SANJIGI);
     public static final Question Q4 = new Question("title4", "contents4").writeBy(UserTest.SANJIGI);
+    public static final Question Q5 = new Question("title5", "contents5").writeBy(UserTest.HONGHEE);
+
+    @DisplayName("정상적으로 삭제가 되는 경우 테스트 - Answer이 존재하지 않음")
+    @Test
+    public void deleteQuestionTest() throws CannotDeleteException {
+
+        // when
+        User loginUser = UserTest.HONGHEE;
+        Question question = QuestionTest.Q5;
+
+        // then
+        List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
+
+        // given
+        Assertions.assertThat(deleteHistories.size()).isEqualTo(1);
+        Assertions.assertThat(question.isDeleted()).isTrue();
+    }
+
+    @DisplayName("정상적으로 삭제가 되는 경우 테스트 - Answer이 존재(작성자가 같은 경우)")
+    @Test
+    public void deleteQuestionWithAnswerTest() throws CannotDeleteException {
+
+        // when
+        User loginUser = UserTest.HONGHEE;
+        Question question = QuestionTest.Q5;
+        Answer answer = AnswerTest.A5;
+        question.addAnswer(answer);
+
+        // then
+        List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
+
+        // given
+        Assertions.assertThat(deleteHistories.size()).isEqualTo(2);
+        Assertions.assertThat(question.isDeleted()).isTrue();
+        Assertions.assertThat(answer.isDeleted()).isTrue();
+    }
+
+    @DisplayName("정상적으로 삭제가 되지 않는 경우 테스트 - Answer이 존재하지 않음")
+    @Test
+    public void deleteQuestionFailureTest() {
+
+        // when
+        User loginUser = UserTest.HONGHEE;
+        Question question = QuestionTest.Q1;
+
+        // then
+        Assertions.assertThatThrownBy(() -> {
+            List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
+            Assertions.assertThat(deleteHistories).isNull();
+        }).isInstanceOf(CannotDeleteException.class);
+
+        // given
+        Assertions.assertThat(question.isDeleted()).isFalse();
+    }
+
+    @DisplayName("정상적으로 삭제가 되지 않는 경우 테스트 - Answer이 존재(작성자가 다른 경우)")
+    @Test
+    public void deleteQuestionWithAnswerFailureTest() {
+
+        // when
+        User loginUser = UserTest.SANJIGI;
+        Question question = QuestionTest.Q3;
+        Answer answer = AnswerTest.A1;
+        question.addAnswer(answer);
+
+        // then
+        Assertions.assertThatThrownBy(() -> {
+            List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
+            Assertions.assertThat(deleteHistories).isNull();
+        }).isInstanceOf(CannotDeleteException.class);
+
+        // given
+        Assertions.assertThat(question.isDeleted()).isFalse();
+        Assertions.assertThat(answer.isDeleted()).isFalse();
+    }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -47,7 +47,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Collections.singletonList(answer));
+        // when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Collections.singletonList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -67,7 +67,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        // when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -82,7 +82,7 @@ class QnaServiceTest {
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
+        // when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);


### PR DESCRIPTION
안녕하세요? 먼저 step2에서 질문한 내용에 친철하게 답변해주셔서 감사합니다! 그런데 몇가지 궁금한 점이 더 생겼는데요 😅
```
public void setLine(Line line) {
    this.line = line;
    line.getStations().add(this); // (2)
}
public void addStation(Station station) {
    stations.add(station); // (1) 
    station.setLine(this);
}
Line에 addStation 호출하여 연관관계 설정 할 때 보면
line.getStations()는 결국 Line의 stations를 가리키고 있기 때문에
(1)과 (2)에 의해서 Line의 stations에는 두 개의 역이 들어가게 됩니다 😄
```
이렇게 답변을 주셨는데요! 사실 step3을 진행하면서도 위와 같은 이슈로 한가지 문제를 겪었습니다.


QnsServiceTest.java 클래스에서 
```
    @BeforeEach
    public void setUp() throws Exception {
        question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
        answer = new Answer(1L, UserTest.JAVAJIGI, question, "Answers Contents1");
        question.addAnswer(answer); 
    }
```
이렇게 `question.addAnswer(answer); ` 메소드를 호출하면서
```
    public void addAnswer(Answer answer) {
        answers.add(answer);
        answer.toQuestion(this);
    }

    public void toQuestion(Question question) {
        this.question = question;
        question.getAnswers().add(this);
    }
```
관계 편의성 메소드로 인해서 Question클래스에 동일한 Answer가 2개가 들어가게 됩니다!
근데 제가 이번에 리팩토링을 하면서 
```
    @Transactional(readOnly = true)
    public Question findQuestionById(Long id) {
        return questionRepository.findByIdAndDeletedFalse(id)
                .orElseThrow(NotFoundException::new);
    }

    @Transactional
    public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
        Question question = findQuestionById(questionId);  // read data from db - 연관관계 매핑으로 answers 도 같이 읽어올 수 있음
        List<DeleteHistory> deleteHistories = question.deleteQuestion(loginUser);
        deleteHistoryService.saveAll(deleteHistories);
    }
```

단순히 Question Id 를 통해서 Question 객체를 가져오면 연관관계 매핑에 의해서 Answer 데이터도 같이 가져오게 됩니다!
그런데 위의 경우는 테스트 클래스에서 @BeforeEach 함수에서  question.addAnswer(answer);  메소드 때문에 Qeustion에 이미 2개의 Answer가 들어가게되고 
`when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));` 이 Mocking 부분에 의해서 2개의 Answer를 가진 Question 객체가 리턴이 됩니다.

그래서 Answer 객체가 2개라서 
```
    private void verifyDeleteHistories() {
        List<DeleteHistory> deleteHistories = Arrays.asList(
                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
        );
        verify(deleteHistoryService).saveAll(deleteHistories);
    }
``` 
이부분에서 계속 실패가 나는 현상이 발생했습니다.


그래서 어쩔수 없이 List => Set으로 자료구조를 변경하면서 문제를 해결했습니다.
```
    @OneToMany
    @JoinColumn(name = "question_id")
    private Set<Answer> answers = new HashSet<>();
```

하지만 추후에 answers 의 개수를 저장한다던가,  answers를 가지고 비지니스 로직을 수행할 때 분명 문제가 될 것 같습니다.
연관관계 편의 메소드를 통해서 구현되어야하는게 맞는건지 지금으로썬 살짝 의문이 가네요 😭✍️


