### PR TITLE
Step2 - 연관 관계 매핑

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -6,6 +6,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import qna.NotFoundException;
@@ -32,7 +33,7 @@ public class Answer extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "clob")
+    @Lob
     private String contents;
 
     private boolean deleted = false;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,18 +1,16 @@
 package qna.domain;
 
-import java.sql.Timestamp;
-import javax.persistence.Column;
+import java.util.Objects;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
-import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.annotation.CreatedDate;
+import javax.persistence.ManyToOne;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
-
-import java.util.Objects;
 
 /**
  * create table answer
@@ -38,9 +36,13 @@ public class Answer extends BaseTimeEntity {
 
     private boolean deleted = false;
 
-    private Long questionId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
 
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
 
     protected Answer() {
     }
@@ -60,17 +62,17 @@ public class Answer extends BaseTimeEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.setQuestion(question);
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
@@ -81,20 +83,26 @@ public class Answer extends BaseTimeEntity {
         this.id = id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public Question getQuestion() {
+        return question;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public void setQuestion(Question question) {
+        if (Objects.nonNull(this.question)) {
+            this.question.getAnswers().remove(this);
+        }
+        if (Objects.nonNull(question)) {
+            this.toQuestion(question);
+            question.getAnswers().add(this);
+        }
     }
 
-    public Long getQuestionId() {
-        return questionId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 
     public String getContents() {
@@ -117,8 +125,8 @@ public class Answer extends BaseTimeEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
+                ", writer=" + writer +
+                ", question=" + question +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -10,5 +10,5 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 
-    Answer findAnswerByWriterId(Long writerId);
+    List<Answer> findAnswerByWriterId(Long writerId);
 }

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -11,4 +11,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 
     List<Answer> findAnswerByWriterId(Long writerId);
+
+    List<Answer> findAnswerByQuestionId(Long questionId);
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -2,13 +2,15 @@ package qna.domain;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 /**
  * create table delete_history
@@ -32,16 +34,18 @@ public class DeleteHistory {
     @Enumerated(EnumType.STRING)
     private ContentType contentType;
 
-    private Long deletedById;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
 
     private LocalDateTime createDate = LocalDateTime.now();
 
     protected DeleteHistory() {}
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -53,12 +57,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&
                 Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+                Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedBy);
     }
 
     @Override
@@ -67,7 +71,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deletedBy=" + deletedBy +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -27,7 +29,7 @@ public class DeleteHistory {
 
     private Long contentId;
 
-    @Column(columnDefinition = "varchar(255)")
+    @Enumerated(EnumType.STRING)
     private ContentType contentType;
 
     private Long deletedById;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,18 @@
 package qna.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 /**
  * create table question
@@ -34,7 +41,12 @@ public class Question extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String title;
 
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
+
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers = new ArrayList<>();
 
     protected Question() {
     }
@@ -50,16 +62,19 @@ public class Question extends BaseTimeEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
-        answer.toQuestion(this);
+        if (Objects.nonNull(answer)) {
+            answers.add(answer);
+            answer.toQuestion(this);
+        }
     }
 
     public Long getId() {
@@ -86,12 +101,12 @@ public class Question extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 
     public boolean isDeleted() {
@@ -102,13 +117,24 @@ public class Question extends BaseTimeEntity {
         this.deleted = deleted;
     }
 
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+
+    public void setAnswers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public Answer getLastAnswer() {
+        return answers.size() > 0? answers.get(answers.size() - 1) : null;
+    }
     @Override
     public String toString() {
         return "Question{" +
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -5,6 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 
 /**
  * create table question
@@ -25,12 +26,12 @@ public class Question extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "clob")
+    @Lob
     private String contents;
 
     private boolean deleted = false;
 
-    @Column(length = 100)
+    @Column(length = 100, nullable = false)
     private String title;
 
     private Long writerId;

--- a/src/main/java/qna/domain/QuestionRepository.java
+++ b/src/main/java/qna/domain/QuestionRepository.java
@@ -10,5 +10,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
   Optional<Question> findByIdAndDeletedFalse(Long id);
 
-  Question findFirstByTitle(String title);
+  Optional<Question> findFirstByTitle(String title);
+
+  List<Question> findQuestionsByWriterId(Long writerId);
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -16,9 +16,9 @@ import java.util.List;
 public class QnaService {
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
-    private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
-    private DeleteHistoryService deleteHistoryService;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final DeleteHistoryService deleteHistoryService;
 
     public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+-- USERS
+INSERT INTO user (id, user_id, password, name, email) VALUES (1, 'javajigi', 'password', 'name', 'javajigi@slipp.net');
+INSERT INTO user (id, user_id, password, name, email) VALUES (2, 'sanjigi', 'password', 'name', 'sanjigi@slipp.net');
+
+-- QUESTIONS
+INSERT INTO question (id, title, contents, writer_id, deleted) VALUES (1, 'title1', 'contents1', 1, false);
+INSERT INTO question (id, title, contents, writer_id, deleted) VALUES (2, 'title2', 'contents2', 2, false);
+
+-- ANSWERS
+INSERT INTO answer (writer_id, question_id, contents, deleted) VALUES (1, 1, 'Answers Contents1', false);
+INSERT INTO answer (writer_id, question_id, contents, deleted) VALUES (2, 1, 'Answers Contents2', false);

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -4,67 +4,68 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 public class AnswerTest {
+    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1,
+        "Answers Contents1");
+    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1,
+        "Answers Contents2");
 
-  @Autowired
-  AnswerRepository answers;
+    @Autowired
+    private AnswerRepository answers;
 
-  public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1,
-      "Answers Contents1");
-  public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1,
-      "Answers Contents2");
+    @Test
+    @DisplayName("Create Answer - 저장된 ID, contents 확인")
+    void saveAnswer() {
+        Answer savedAnswer = answers.save(A1);
 
-  @Test
-  void saveAnswer() {
-    Answer savedAnswer = answers.save(A1);
+        assertAll(
+            () -> assertThat(savedAnswer.getId()).isNotNull(),
+            () -> assertThat(savedAnswer.getContents()).isEqualTo(A1.getContents())
+        );
+    }
 
-    assertAll(
-        ()-> assertThat(savedAnswer.getId()).isNotNull(),
-        ()-> assertThat(savedAnswer.getContents()).isEqualTo(A1.getContents())
-    );
-  }
+    @Test
+    @DisplayName("Read Answer - writerId로 조회한 Answer 의 Id, Question Id를 확인")
+    void findAnswerByWriterId() {
+        Answer savedAnswer = answers.save(A1);
+        Answer foundAnswer = answers.findAnswerByWriterId(A1.getWriterId()).get(0);
 
-  @Test
-  void findAnswerByWriterId() {
-    Answer savedAnswer = answers.save(A1);
-    Answer foundAnswer = answers.findAnswerByWriterId(A1.getWriterId());
+        assertAll(
+            () -> assertThat(foundAnswer.getId()).isNotNull(),
+            () -> assertThat(foundAnswer.getQuestionId()).isEqualTo(savedAnswer.getQuestionId())
+        );
+    }
 
-    assertAll(
-        ()-> assertThat(foundAnswer.getId()).isNotNull(),
-        ()-> assertThat(foundAnswer.getQuestionId()).isEqualTo(savedAnswer.getQuestionId())
-    );
-  }
+    @Test
+    @DisplayName("Update Answer - contents 변경 후 변경된 내용 확인")
+    void updateAnswer() {
+        Answer savedAnswer = answers.save(A1);
+        Answer foundAnswer = answers.findById(savedAnswer.getId()).get();
 
-  @Test
-  void updateAnswer() {
-    Answer savedAnswer = answers.save(A1);
-    Answer foundAnswer = answers.findById(savedAnswer.getId()).get();
+        foundAnswer.setContents(A2.getContents());
+        Optional<Answer> foundAnswerOptional = answers.findById(savedAnswer.getId());
 
-    foundAnswer.setContents(A2.getContents());
-    Optional<Answer> foundAnswerOptional = answers.findById(savedAnswer.getId());
+        assertAll(
+            () -> assertThat(foundAnswerOptional).isPresent(),
+            () -> assertThat(foundAnswerOptional.get().getContents()).isEqualTo(A2.getContents())
+        );
+    }
 
-    assertAll(
-        ()-> assertThat(foundAnswerOptional).isPresent(),
-        ()-> assertThat(foundAnswerOptional.get().getContents()).isEqualTo(A2.getContents())
-    );
-  }
+    @Test
+    @DisplayName("Delete Answer - 삭제 후 존재하지 않는 것을 확인")
+    void deleteAnswer() {
+        Answer savedAnswer = answers.save(A1);
+        answers.delete(savedAnswer);
+        Optional<Answer> answerOptional = answers.findById(savedAnswer.getId());
 
-  @Test
-  void deleteAnswer() {
-    Answer savedAnswer = answers.save(A1);
-    answers.delete(savedAnswer);
-    Optional<Answer> answerOptional = answers.findById(savedAnswer.getId());
+        assertThat(answerOptional).isNotPresent();
 
-    assertThat(answerOptional).isNotPresent();
-
-  }
+    }
 
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -2,7 +2,10 @@ package qna.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static qna.domain.QuestionTest.Q1;
+import static qna.domain.QuestionTest.Q2;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,61 +14,113 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 public class AnswerTest {
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1,
+    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, Q1,
         "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1,
+    public static final Answer A2 = new Answer(UserTest.SANJIGI, Q1,
         "Answers Contents2");
+
+    @Autowired
+    private UserRepository users;
+
+    @Autowired
+    private QuestionRepository questions;
 
     @Autowired
     private AnswerRepository answers;
 
+    private User findUser(User user) {
+        Optional<User> foundUser = users.findByUserId(UserTest.JAVAJIGI.getUserId());
+        return foundUser.orElseGet(() -> users.save(user));
+    }
+
+    private Question findQuestion(Question question) {
+        Optional<Question> foundQuestion = questions.findFirstByTitle(question.getTitle());
+        return foundQuestion.orElseGet(() -> questions.save(question));
+    }
+
     @Test
-    @DisplayName("Create Answer - 저장된 ID, contents 확인")
+    @DisplayName("Answer 저장 테스트")
     void saveAnswer() {
-        Answer savedAnswer = answers.save(A1);
+        Question question = findQuestion(Q2);
+        Answer expected = new Answer(findUser(UserTest.JAVAJIGI), question, "Answers Contents3");
+        Answer actual = answers.save(expected);
 
         assertAll(
-            () -> assertThat(savedAnswer.getId()).isNotNull(),
-            () -> assertThat(savedAnswer.getContents()).isEqualTo(A1.getContents())
+            () -> assertThat(actual.getId()).isNotNull(),
+            () -> assertThat(actual.getContents()).isEqualTo(expected.getContents()),
+            // 관계성 체크
+            () -> assertThat(actual.getQuestion()).isEqualTo(question),
+            () -> assertThat(question.getLastAnswer()).isEqualTo(actual)
         );
     }
 
     @Test
-    @DisplayName("Read Answer - writerId로 조회한 Answer 의 Id, Question Id를 확인")
+    @DisplayName("Answer 조회 테스트")
     void findAnswerByWriterId() {
-        Answer savedAnswer = answers.save(A1);
-        Answer foundAnswer = answers.findAnswerByWriterId(A1.getWriterId()).get(0);
+        // A1 을 조회
+        Answer expected = A1;
+        List<Answer> actual = answers.findAnswerByWriterId(expected.getWriter().getId());
 
         assertAll(
-            () -> assertThat(foundAnswer.getId()).isNotNull(),
-            () -> assertThat(foundAnswer.getQuestionId()).isEqualTo(savedAnswer.getQuestionId())
+            () -> assertThat(actual).isNotNull(),
+            () -> assertThat(actual.size()).isGreaterThan(0),
+            () -> assertThat(actual.get(0).getId()).isNotNull(),
+            () -> assertThat(actual.get(0).getContents()).isEqualTo(expected.getContents())
         );
     }
 
     @Test
-    @DisplayName("Update Answer - contents 변경 후 변경된 내용 확인")
+    @DisplayName("Answer 수정 테스트 - Contents 수정")
     void updateAnswer() {
-        Answer savedAnswer = answers.save(A1);
-        Answer foundAnswer = answers.findById(savedAnswer.getId()).get();
+        Answer answerBefore = answers.findAnswerByWriterId(A1.getWriter().getId()).get(0);
 
-        foundAnswer.setContents(A2.getContents());
-        Optional<Answer> foundAnswerOptional = answers.findById(savedAnswer.getId());
+        // A2 contents 로 수정
+        answerBefore.setContents(A2.getContents());
+
+        Answer answerAfter = answers.findAnswerByWriterId(A1.getWriter().getId()).get(0);
 
         assertAll(
-            () -> assertThat(foundAnswerOptional).isPresent(),
-            () -> assertThat(foundAnswerOptional.get().getContents()).isEqualTo(A2.getContents())
+            () -> assertThat(answerAfter.getId()).isEqualTo(answerBefore.getId()),
+            () -> assertThat(answerAfter.getContents()).isEqualTo(A2.getContents())
         );
     }
 
     @Test
-    @DisplayName("Delete Answer - 삭제 후 존재하지 않는 것을 확인")
+    @DisplayName("Answer 수정 테스트 - mapping question 수정")
+    void updateAnswerWithQuestion() {
+        final Long targetWriterId = A1.getWriter().getId();
+        Answer answerBefore = answers.findAnswerByWriterId(targetWriterId).get(0);
+
+        // Answer의 question mapping Q1 -> Q2 로 수정
+        Question questionBefore = findQuestion(Q1);
+        Question questionAfter = findQuestion(Q2);
+        answerBefore.setQuestion(questionAfter);
+
+        Answer answerAfter = answers.findAnswerByWriterId(targetWriterId).get(0);
+
+        assertAll(
+            () -> assertThat(answerAfter.getQuestion()).isEqualTo(questionAfter),
+            () -> assertThat(answerAfter).isEqualTo(questionAfter.getLastAnswer()),
+            () -> assertThat(answerAfter).isNotEqualTo(questionBefore.getLastAnswer())
+        );
+    }
+
+    @Test
+    @DisplayName("Answer 삭제 테스트")
     void deleteAnswer() {
-        Answer savedAnswer = answers.save(A1);
-        answers.delete(savedAnswer);
-        Optional<Answer> answerOptional = answers.findById(savedAnswer.getId());
+        Long targetAnswerWriterId = 1L;
+        List<Answer> answerBefore = answers.findAnswerByWriterId(targetAnswerWriterId);
 
-        assertThat(answerOptional).isNotPresent();
+        answerBefore.forEach(answer -> {
+            // 연관 관계 삭제 (메모리 sync)
+            answer.setQuestion(null);
+            // answer 삭제
+            answers.delete(answer);
+        });
 
+        List<Answer> answerAfter = answers.findAnswerByWriterId(targetAnswerWriterId);
+
+        assertThat(answerAfter).isEmpty();
     }
 
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -4,67 +4,72 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 public class QuestionTest {
+    public static final Question Q1 = new Question("title1", "contents1")
+        .writeBy(UserTest.JAVAJIGI);
+    public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
 
-  @Autowired
-  private QuestionRepository questions;
+    @Autowired
+    private QuestionRepository questions;
 
-  public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
-  public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+    @Test
+    @DisplayName("Create Question - 저장된 ID, contents 확인")
+    void saveQuestion() {
+        Question savedQuestion = questions.save(Q1);
 
-  @Test
-  void saveQuestion() {
-    Question savedQuestion = questions.save(Q1);
+        assertAll(
+            () -> assertThat(savedQuestion.getId()).isNotNull(),
+            () -> assertThat(savedQuestion.getContents()).isEqualTo(Q1.getContents())
+        );
+    }
 
-    assertAll(
-        () -> assertThat(savedQuestion.getId()).isNotNull(),
-        () -> assertThat(savedQuestion.getContents()).isEqualTo(Q1.getContents())
-    );
-  }
+    @Test
+    @DisplayName("Read Question - title 로 조회한 Question 의 Id, contents 를 확인")
+    void findByTitle() {
+        Question savedQuestion = questions.save(Q1);
+        Question foundQuestion = questions.findFirstByTitle(Q1.getTitle());
 
-  @Test
-  void findByTitle() {
-    Question savedQuestion = questions.save(Q1);
-    Question foundQuestion = questions.findFirstByTitle(Q1.getTitle());
+        assertAll(
+            () -> assertThat(foundQuestion.getId()).isNotNull(),
+            () -> assertThat(foundQuestion.getContents()).isEqualTo(savedQuestion.getContents())
+        );
+    }
 
-    assertAll(
-        () -> assertThat(foundQuestion.getId()).isNotNull(),
-        () -> assertThat(foundQuestion.getContents()).isEqualTo(savedQuestion.getContents())
-    );
-  }
+    @Test
+    @DisplayName("Update Question - deleted 값 변경 후 변경된 내용 확인")
+    void updateQuestion() {
+        Question savedQuestion = questions.save(Q1);
+        Question foundQuestion = questions.findByIdAndDeletedFalse(savedQuestion.getId()).get();
+        foundQuestion.setDeleted(true);
 
-  @Test
-  void updateQuestion() {
-    Question savedQuestion = questions.save(Q1);
-    Question foundQuestion = questions.findByIdAndDeletedFalse(savedQuestion.getId()).get();
-    foundQuestion.setDeleted(true);
+        Optional<Question> foundQuestionById = questions.findById(savedQuestion.getId());
+        Optional<Question> foundQuestionByIdAndDeletedFalse = questions
+            .findByIdAndDeletedFalse(savedQuestion.getId());
 
-    Optional<Question> foundQuestionById = questions.findById(savedQuestion.getId());
-    Optional<Question> foundQuestionByIdAndDeletedFalse = questions
-        .findByIdAndDeletedFalse(savedQuestion.getId());
+        assertAll(
+            () -> assertThat(foundQuestionById).isPresent(),
+            () -> assertThat(foundQuestionByIdAndDeletedFalse).isNotPresent()
+        );
+    }
 
-    assertAll(
-        () -> assertThat(foundQuestionById).isPresent(),
-        () -> assertThat(foundQuestionByIdAndDeletedFalse).isNotPresent()
-    );
-  }
+    @Test
+    @DisplayName("Delete Question - 삭제 후 존재하지 않는 것을 확인")
+    void deleteQuestion() {
+        Question savedQuestion = questions.save(Q1);
+        Question foundQuestion = questions.findById(savedQuestion.getId()).get();
 
-  @Test
-  void deleteQuestion() {
-    Question savedQuestion = questions.save(Q1);
-    Question foundQuestion = questions.findById(savedQuestion.getId()).get();
+        questions.delete(foundQuestion);
 
-    questions.delete(foundQuestion);
+        Optional<Question> foundQuestionById = questions.findById(savedQuestion.getId());
 
-    Optional<Question> foundQuestionById = questions.findById(savedQuestion.getId());
-
-    assertAll(
-        () -> assertThat(foundQuestionById).isNotPresent()
-    );
-  }
+        assertAll(
+            () -> assertThat(foundQuestionById).isNotPresent()
+        );
+    }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -3,6 +3,7 @@ package qna.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,10 +16,16 @@ public class UserTest {
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
 
     @Autowired
+    private AnswerRepository answers;
+
+    @Autowired
+    private QuestionRepository questions;
+
+    @Autowired
     private UserRepository users;
 
     @Test
-    @DisplayName("Create User - 저장된 ID, email 확인")
+    @DisplayName("User 저장 테스트")
     void saveUser() {
         User savedUser = users.save(JAVAJIGI);
 
@@ -29,45 +36,63 @@ public class UserTest {
     }
 
     @Test
-    @DisplayName("Read User - userId 로 조회한 User 의 Id, Name 을 확인")
+    @DisplayName("User 조회 테스트")
     void findByUserId() {
-        User savedUser = users.save(JAVAJIGI);
-        Optional<User> foundUser = users.findByUserId(JAVAJIGI.getUserId());
+        // JAVAJIGI 조회
+        User expected = JAVAJIGI;
+        Optional<User> actual = users.findByUserId(expected.getUserId());
 
         assertAll(
-            () -> assertThat(foundUser).isPresent(),
-            () -> assertThat(foundUser.get().getId()).isNotNull(),
-            () -> assertThat(foundUser.get().getName()).isEqualTo(savedUser.getName())
+            () -> assertThat(actual).isPresent(),
+            () -> assertThat(actual.get().getId()).isNotNull(),
+            () -> assertThat(actual.get().getName()).isEqualTo(expected.getName())
         );
     }
 
     @Test
-    @DisplayName("Update User - userId 변경 후 변경된 내용 확인")
+    @DisplayName("User 수정 테스트")
     void updateUser() {
-        User savedUser = users.save(JAVAJIGI);
-        User foundUser = users.findByUserId(JAVAJIGI.getUserId()).get();
-        foundUser.setUserId(SANJIGI.getUserId());
+        User userBefore = users.findByUserId(JAVAJIGI.getUserId()).get();
 
-        Optional<User> foundUserByUserId = users.findByUserId(SANJIGI.getUserId());
+        // email 수정
+        userBefore.setEmail(SANJIGI.getEmail());
+
+        User userAfter = users.findByUserId(JAVAJIGI.getUserId()).get();
 
         assertAll(
-            () -> assertThat(foundUserByUserId).isPresent(),
-            () -> assertThat(foundUser).isSameAs(foundUserByUserId.get())
+            () -> assertThat(userAfter.getId()).isEqualTo(userBefore.getId()),
+            () -> assertThat(userAfter.getEmail()).isEqualTo(SANJIGI.getEmail())
         );
     }
 
     @Test
-    @DisplayName("Delete User - 삭제 후 존재하지 않는 것을 확인")
+    @DisplayName("User 삭제 테스트")
     void deleteUser() {
-        User savedUser = users.save(JAVAJIGI);
-        User foundUser = users.findByUserId(JAVAJIGI.getUserId()).get();
+        final User targetUser = JAVAJIGI;
 
-        users.delete(foundUser);
+        User userBefore = users.findByUserId(targetUser.getUserId()).get();
+        List<Answer> answerListBefore = answers.findAnswerByWriterId(JAVAJIGI.getId());
+        List<Question> questionListBefore = questions.findQuestionsByWriterId(JAVAJIGI.getId());
 
-        Optional<User> foundUserByUserId = users.findByUserId(foundUser.getUserId());
+        // 연관 관계 객체 삭제
+        answerListBefore.forEach(answer -> {
+            answers.delete(answer);
+        });
+        questionListBefore.forEach(question -> {
+            List<Answer> answerListOfQuestion = answers.findAnswerByQuestionId(question.getId());
+            answerListOfQuestion.forEach(answer -> {
+                answers.delete(answer);
+            });
+            questions.delete(question);
+        });
+
+        // user 삭제
+        users.delete(userBefore);
+
+        Optional<User> userAfter = users.findByUserId(targetUser.getUserId());
 
         assertAll(
-            () -> assertThat(foundUserByUserId).isNotPresent()
+            () -> assertThat(userAfter).isNotPresent()
         );
     }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -4,20 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 public class UserTest {
+    public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+    public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
 
     @Autowired
     private UserRepository users;
 
-    public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-    public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
-
     @Test
+    @DisplayName("Create User - 저장된 ID, email 확인")
     void saveUser() {
         User savedUser = users.save(JAVAJIGI);
 
@@ -28,6 +29,7 @@ public class UserTest {
     }
 
     @Test
+    @DisplayName("Read User - userId 로 조회한 User 의 Id, Name 을 확인")
     void findByUserId() {
         User savedUser = users.save(JAVAJIGI);
         Optional<User> foundUser = users.findByUserId(JAVAJIGI.getUserId());
@@ -40,6 +42,7 @@ public class UserTest {
     }
 
     @Test
+    @DisplayName("Update User - userId 변경 후 변경된 내용 확인")
     void updateUser() {
         User savedUser = users.save(JAVAJIGI);
         User foundUser = users.findByUserId(JAVAJIGI.getUserId()).get();
@@ -54,6 +57,7 @@ public class UserTest {
     }
 
     @Test
+    @DisplayName("Delete User - 삭제 후 존재하지 않는 것을 확인")
     void deleteUser() {
         User savedUser = users.save(JAVAJIGI);
         User foundUser = users.findByUserId(JAVAJIGI.getUserId()).get();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
안녕하세요! step2 진도가 늦었습니다! (헐레벌떡)

2단계 구현하면서, 1단계에서 주신 리뷰도 함께 피드백 적용했습니다!
indent 세팅이 혼동이 있었어서 convention을 다시 적용했더니 
코드가 많이 바뀐 것으로 되어 보기 불편하시게 되었네요 :( 송구함다.

그럼 오늘도 잘부탁드립니다! :) 
감사합니다.

--------------------------------------------

feat: domain entity에 연관 관계 매핑
  - answer - question 양방향
  - answer - user 다대일 단방향
  - question - user 다대일 단방향
  - deleteHistory - user 다대일 단방향
 
test: 연관 관계 테스트 추가
  - data.sql을 통하여 기본 데이터가 있는 상태로 설정
  - update test 시 연관 관계를 테스트 하도록 추가
  - delete test 시 연관 관계를 우선 삭제, 정리하도록 구현