### PR TITLE
Feat: JPA 2단계 연관관계 구현

### DIFF
--- a/src/main/java/qna/Application.java
+++ b/src/main/java/qna/Application.java
@@ -2,8 +2,10 @@ package qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,16 +1,34 @@
 package qna.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import java.util.Objects;
 
-public class Answer {
+@Entity
+public class Answer extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long writerId;
-    private Long questionId;
+
+    @Lob
     private String contents;
+
+    @Column(name = "deleted", nullable = false)
     private boolean deleted = false;
+
+    @Column(name = "question_id")
+    private Long questionId;
+
+    @Column(name = "writer_id")
+    private Long writerId;
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -81,13 +99,33 @@ public class Answer {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Answer answer = (Answer) o;
+        return deleted == answer.deleted && Objects.equals(id, answer.id) && Objects
+            .equals(contents, answer.contents) && Objects
+            .equals(questionId, answer.questionId) && Objects
+            .equals(writerId, answer.writerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, contents, deleted, questionId, writerId);
+    }
+
+    @Override
     public String toString() {
         return "Answer{" +
-                "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
-                ", contents='" + contents + '\'' +
-                ", deleted=" + deleted +
-                '}';
+            "id=" + id +
+            ", writerId=" + writerId +
+            ", questionId=" + questionId +
+            ", contents='" + contents + '\'' +
+            ", deleted=" + deleted +
+            '}';
     }
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -2,14 +2,18 @@ package qna.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import java.util.Objects;
+import qna.domain.User;
 
 @Entity
 public class Answer extends BaseTimeEntity {
@@ -24,11 +28,13 @@ public class Answer extends BaseTimeEntity {
     @Column(name = "deleted", nullable = false)
     private boolean deleted = false;
 
-    @Column(name = "question_id")
-    private Long questionId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"), name = "question_id")
+    private Question question;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"), name = "writer_id")
+    private User writer;
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -45,49 +51,33 @@ public class Answer extends BaseTimeEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer.getId());
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public User getWriter() {
+        return writer;
     }
 
     public Long getWriterId() {
-        return writerId;
+        return writer.getId();
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
-
-    public Long getQuestionId() {
-        return questionId;
-    }
-
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
+    public Question getQuestion() {
+        return question;
     }
 
     public boolean isDeleted() {
@@ -109,21 +99,21 @@ public class Answer extends BaseTimeEntity {
         Answer answer = (Answer) o;
         return deleted == answer.deleted && Objects.equals(id, answer.id) && Objects
             .equals(contents, answer.contents) && Objects
-            .equals(questionId, answer.questionId) && Objects
-            .equals(writerId, answer.writerId);
+            .equals(question, answer.question) && Objects
+            .equals(writer, answer.writer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contents, deleted, questionId, writerId);
+        return Objects.hash(id, contents, deleted, question, writer);
     }
 
     @Override
     public String toString() {
         return "Answer{" +
             "id=" + id +
-            ", writerId=" + writerId +
-            ", questionId=" + questionId +
+            ", writerId=" + writer +
+            ", questionId=" + question +
             ", contents='" + contents + '\'' +
             ", deleted=" + deleted +
             '}';

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
     List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
 
     Optional<Answer> findByIdAndDeletedFalse(Long id);

--- a/src/main/java/qna/domain/BaseTimeEntity.java
+++ b/src/main/java/qna/domain/BaseTimeEntity.java
@@ -1,0 +1,29 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -6,9 +6,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import jdk.jfr.Timestamp;
 import org.hibernate.annotations.CreationTimestamp;
@@ -26,15 +29,17 @@ public class DeleteHistory {
 
     private Long contentId;
 
-    private Long deletedById;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_delete_history_to_user"), name = "deleted_by_id")
+    private User deletedBy;
 
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById,
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy,
         LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -50,12 +55,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
             contentType == that.contentType &&
             Objects.equals(contentId, that.contentId) &&
-            Objects.equals(deletedById, that.deletedById);
+            Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedBy);
     }
 
     @Override
@@ -64,7 +69,7 @@ public class DeleteHistory {
             "id=" + id +
             ", contentType=" + contentType +
             ", contentId=" + contentId +
-            ", deletedById=" + deletedById +
+            ", deletedById=" + deletedBy +
             ", createDate=" + createDate +
             '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -2,15 +2,36 @@ package qna.domain;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import jdk.jfr.Timestamp;
+import org.hibernate.annotations.CreationTimestamp;
 
+@Entity
 public class DeleteHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 255)
     private ContentType contentType;
+
     private Long contentId;
+
     private Long deletedById;
+
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById,
+        LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
         this.deletedById = deletedById;
@@ -19,13 +40,17 @@ public class DeleteHistory {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DeleteHistory that = (DeleteHistory) o;
         return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+            contentType == that.contentType &&
+            Objects.equals(contentId, that.contentId) &&
+            Objects.equals(deletedById, that.deletedById);
     }
 
     @Override
@@ -36,11 +61,11 @@ public class DeleteHistory {
     @Override
     public String toString() {
         return "DeleteHistory{" +
-                "id=" + id +
-                ", contentType=" + contentType +
-                ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
-                ", createDate=" + createDate +
-                '}';
+            "id=" + id +
+            ", contentType=" + contentType +
+            ", contentId=" + contentId +
+            ", deletedById=" + deletedById +
+            ", createDate=" + createDate +
+            '}';
     }
 }

--- a/src/main/java/qna/domain/DeleteHistoryRepository.java
+++ b/src/main/java/qna/domain/DeleteHistoryRepository.java
@@ -3,4 +3,5 @@ package qna.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeleteHistoryRepository extends JpaRepository<DeleteHistory, Long> {
+
 }

--- a/src/main/java/qna/domain/Email.java
+++ b/src/main/java/qna/domain/Email.java
@@ -1,0 +1,41 @@
+package qna.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Email {
+
+    @Column(length = 50)
+    private String email;
+
+
+    public Email(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Email email1 = (Email) o;
+        return Objects.equals(email, email1.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email);
+    }
+
+    @Override
+    public String toString() {
+        return "Email{" +
+            "email='" + email + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/qna/domain/Name.java
+++ b/src/main/java/qna/domain/Name.java
@@ -1,0 +1,40 @@
+package qna.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Name {
+
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    public Name(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Name name1 = (Name) o;
+        return name.equals(name1.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "Name{" +
+            "name='" + name + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/qna/domain/Password.java
+++ b/src/main/java/qna/domain/Password.java
@@ -1,0 +1,40 @@
+package qna.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Password {
+
+    @Column(length = 20, nullable = false)
+    private String password;
+
+    public Password(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Password password1 = (Password) o;
+        return password.equals(password1.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(password);
+    }
+
+    @Override
+    public String toString() {
+        return "Password{" +
+            "password='" + password + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,10 +1,31 @@
 package qna.domain;
 
-public class Question {
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "question")
+public class Question extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, length = 100)
     private String title;
+
+    @Lob
     private String contents;
+
     private Long writerId;
+
+    @Column(nullable = false)
     private boolean deleted = false;
 
     public Question(String title, String contents) {
@@ -71,13 +92,32 @@ public class Question {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Question question = (Question) o;
+        return deleted == question.deleted && Objects.equals(id, question.id) && title
+            .equals(question.title) && Objects.equals(contents, question.contents)
+            && Objects.equals(writerId, question.writerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, contents, writerId, deleted);
+    }
+
+    @Override
     public String toString() {
         return "Question{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
-                ", deleted=" + deleted +
-                '}';
+            "id=" + id +
+            ", title='" + title + '\'' +
+            ", contents='" + contents + '\'' +
+            ", writerId=" + writerId +
+            ", deleted=" + deleted +
+            '}';
     }
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -3,10 +3,13 @@ package qna.domain;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -23,7 +26,9 @@ public class Question extends BaseTimeEntity {
     @Lob
     private String contents;
 
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"), name = "writer_id")
+    private User writer;
 
     @Column(nullable = false)
     private boolean deleted = false;
@@ -39,12 +44,12 @@ public class Question extends BaseTimeEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer.getId());
     }
 
     public void addAnswer(Answer answer) {
@@ -75,12 +80,16 @@ public class Question extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public Long getWriterId() {
+        return writer.getId();
+    }
+
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 
     public boolean isDeleted() {
@@ -102,12 +111,12 @@ public class Question extends BaseTimeEntity {
         Question question = (Question) o;
         return deleted == question.deleted && Objects.equals(id, question.id) && title
             .equals(question.title) && Objects.equals(contents, question.contents)
-            && Objects.equals(writerId, question.writerId);
+            && Objects.equals(writer, question.writer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, title, contents, writerId, deleted);
+        return Objects.hash(id, title, contents, writer, deleted);
     }
 
     @Override
@@ -116,7 +125,7 @@ public class Question extends BaseTimeEntity {
             "id=" + id +
             ", title='" + title + '\'' +
             ", contents='" + contents + '\'' +
-            ", writerId=" + writerId +
+            ", writerId=" + writer +
             ", deleted=" + deleted +
             '}';
     }

--- a/src/main/java/qna/domain/QuestionRepository.java
+++ b/src/main/java/qna/domain/QuestionRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
     List<Question> findByDeletedFalse();
 
     Optional<Question> findByIdAndDeletedFalse(Long id);

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,16 +1,33 @@
 package qna.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import qna.UnAuthorizedException;
 
 import java.util.Objects;
 
-public class User {
+@Entity
+public class User extends BaseTimeEntity {
+
     public static final GuestUser GUEST_USER = new GuestUser();
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(length = 20, nullable = false, unique = true)
     private String userId;
+
+    @Column(length = 20, nullable = false)
     private String password;
+
+    @Column(length = 20, nullable = false)
     private String name;
+
+    @Column(length = 50)
     private String email;
 
     private User() {
@@ -55,7 +72,7 @@ public class User {
         }
 
         return name.equals(target.name) &&
-                email.equals(target.email);
+            email.equals(target.email);
     }
 
     public boolean isGuestUser() {
@@ -103,17 +120,37 @@ public class User {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id) && userId.equals(user.userId) && password
+            .equals(user.password) && name.equals(user.name) && Objects
+            .equals(email, user.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, userId, password, name, email);
+    }
+
+    @Override
     public String toString() {
         return "User{" +
-                "id=" + id +
-                ", userId='" + userId + '\'' +
-                ", password='" + password + '\'' +
-                ", name='" + name + '\'' +
-                ", email='" + email + '\'' +
-                '}';
+            "id=" + id +
+            ", userId='" + userId + '\'' +
+            ", password='" + password + '\'' +
+            ", name='" + name + '\'' +
+            ", email='" + email + '\'' +
+            '}';
     }
 
     private static class GuestUser extends User {
+
         @Override
         public boolean isGuestUser() {
             return true;

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,13 +1,10 @@
 package qna.domain;
 
-import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import qna.UnAuthorizedException;
-
-import java.util.Objects;
 
 @Entity
 public class User extends BaseTimeEntity {
@@ -18,17 +15,8 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20, nullable = false, unique = true)
-    private String userId;
-
-    @Column(length = 20, nullable = false)
-    private String password;
-
-    @Column(length = 20, nullable = false)
-    private String name;
-
-    @Column(length = 50)
-    private String email;
+    @Embedded
+    private UserInfo userInfo;
 
     private User() {
     }
@@ -39,40 +27,11 @@ public class User extends BaseTimeEntity {
 
     public User(Long id, String userId, String password, String name, String email) {
         this.id = id;
-        this.userId = userId;
-        this.password = password;
-        this.name = name;
-        this.email = email;
+        this.userInfo = new UserInfo(userId, password, name, email);
     }
 
     public void update(User loginUser, User target) {
-        if (!matchUserId(loginUser.userId)) {
-            throw new UnAuthorizedException();
-        }
-
-        if (!matchPassword(target.password)) {
-            throw new UnAuthorizedException();
-        }
-
-        this.name = target.name;
-        this.email = target.email;
-    }
-
-    private boolean matchUserId(String userId) {
-        return this.userId.equals(userId);
-    }
-
-    public boolean matchPassword(String targetPassword) {
-        return this.password.equals(targetPassword);
-    }
-
-    public boolean equalsNameAndEmail(User target) {
-        if (Objects.isNull(target)) {
-            return false;
-        }
-
-        return name.equals(target.name) &&
-            email.equals(target.email);
+        this.userInfo.update(loginUser.getUserInfo(), target.getUserInfo());
     }
 
     public boolean isGuestUser() {
@@ -83,71 +42,14 @@ public class User extends BaseTimeEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public UserInfo getUserInfo() {
+        return userInfo;
     }
 
     public String getUserId() {
-        return userId;
+        return this.userInfo.userId();
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        User user = (User) o;
-        return Objects.equals(id, user.id) && userId.equals(user.userId) && password
-            .equals(user.password) && name.equals(user.name) && Objects
-            .equals(email, user.email);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, userId, password, name, email);
-    }
-
-    @Override
-    public String toString() {
-        return "User{" +
-            "id=" + id +
-            ", userId='" + userId + '\'' +
-            ", password='" + password + '\'' +
-            ", name='" + name + '\'' +
-            ", email='" + email + '\'' +
-            '}';
-    }
 
     private static class GuestUser extends User {
 

--- a/src/main/java/qna/domain/UserId.java
+++ b/src/main/java/qna/domain/UserId.java
@@ -1,0 +1,44 @@
+package qna.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class UserId {
+
+    @Column(length = 20, nullable = false, unique = true)
+    private String userId;
+
+    public UserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserId userId1 = (UserId) o;
+        return userId.equals(userId1.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
+    }
+
+    @Override
+    public String toString() {
+        return "UserId{" +
+            "userId='" + userId + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/qna/domain/UserInfo.java
+++ b/src/main/java/qna/domain/UserInfo.java
@@ -1,0 +1,98 @@
+package qna.domain;
+
+import java.util.Objects;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import qna.UnAuthorizedException;
+
+@Embeddable
+public class UserInfo {
+
+    @Embedded
+    private UserId userId;
+
+    @Embedded
+    private Password password;
+
+    @Embedded
+    private Name name;
+
+    @Embedded
+    private Email email;
+
+    public UserInfo(String userId, String password, String name, String email) {
+        this.userId = new UserId(userId);
+        this.password = new Password(password);
+        this.name = new Name(name);
+        this.email = new Email(email);
+    }
+
+    public void update(UserInfo loginUser, UserInfo target) {
+        checkAuthorization(loginUser.getUserId(), target.getPassword());
+        this.name = target.getName();
+        this.email = target.getEmail();
+    }
+
+    private void checkAuthorization(UserId userId, Password password) {
+        if (!this.userId.equals(userId) || !this.password.equals(password)) {
+            throw new UnAuthorizedException();
+        }
+    }
+
+    public String userId() {
+        return userId.getUserId();
+    }
+
+    private UserId getUserId() {
+        return userId;
+    }
+
+    private Password getPassword() {
+        return password;
+    }
+
+    private Name getName() {
+        return name;
+    }
+
+    private Email getEmail() {
+        return email;
+    }
+
+    public boolean equalsNameAndEmail(UserInfo target) {
+        if (Objects.isNull(target)) {
+            return false;
+        }
+
+        return name.equals(target.getName()) &&
+            email.equals(target.getEmail());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserInfo userInfo = (UserInfo) o;
+        return userId.equals(userInfo.userId) && password.equals(userInfo.password) && name
+            .equals(userInfo.name) && Objects.equals(email, userInfo.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, password, name, email);
+    }
+
+    @Override
+    public String toString() {
+        return "UserInfo{" +
+            "userId=" + userId +
+            ", password=" + password +
+            ", name=" + name +
+            ", email=" + email +
+            '}';
+    }
+}

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByUserId(String userId);
 }

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -3,8 +3,10 @@ package qna.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    @Query("SELECT u FROM User u WHERE u.userInfo.userId.userId = :userId")
     Optional<User> findByUserId(String userId);
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import qna.domain.Answer;
 import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.domain.*;
@@ -14,13 +15,15 @@ import java.util.List;
 
 @Service
 public class QnaService {
+
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
     private QuestionRepository questionRepository;
     private AnswerRepository answerRepository;
     private DeleteHistoryService deleteHistoryService;
 
-    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
+    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository,
+        DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
         this.answerRepository = answerRepository;
         this.deleteHistoryService = deleteHistoryService;
@@ -29,7 +32,7 @@ public class QnaService {
     @Transactional(readOnly = true)
     public Question findQuestionById(Long id) {
         return questionRepository.findByIdAndDeletedFalse(id)
-                .orElseThrow(NotFoundException::new);
+            .orElseThrow(NotFoundException::new);
     }
 
     @Transactional
@@ -48,10 +51,14 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(
+            new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(),
+                LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(),
+                    LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.h2.console.enabled=true
+
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
+

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,0 +1,43 @@
+package qna.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import qna.NotFoundException;
+
+@DataJpaTest
+class AnswerRepositoryTest {
+
+    @Autowired
+    AnswerRepository answerRepository;
+
+    private static final Long QUESTION_ID = 1L;
+
+    @Test
+    @DisplayName("questionId를 이용하여 삭제되지 않은 answer 리스트를 반환한다.")
+    void find_not_deleted_answer_with_question_id() {
+        answerRepository.saveAll(Arrays.asList(AnswerTest.A3, AnswerTest.A4));
+        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(QUESTION_ID);
+        for (Answer answer : answers) {
+            assertThat(answer.getQuestionId().equals(QUESTION_ID)).isTrue();
+            assertThat(answer.isDeleted()).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("answerId를 이용하여 삭제되지 않은 answer를 반환한다.")
+    void find_not_deleted_answer_with_id() {
+        Answer requestedAnswer = answerRepository.save(AnswerTest.A3);
+        Answer foundAnswer = answerRepository.findByIdAndDeletedFalse(requestedAnswer.getId())
+            .orElseThrow(NotFoundException::new);
+
+        assertThat(requestedAnswer.equals(foundAnswer)).isTrue();
+    }
+
+}

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
@@ -25,7 +24,7 @@ class AnswerRepositoryTest {
         answerRepository.saveAll(Arrays.asList(AnswerTest.A3, AnswerTest.A4));
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(QUESTION_ID);
         for (Answer answer : answers) {
-            assertThat(answer.getQuestionId().equals(QUESTION_ID)).isTrue();
+            assertThat(answer.getQuestion().equals(QUESTION_ID)).isTrue();
             assertThat(answer.isDeleted()).isFalse();
         }
     }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -3,4 +3,7 @@ package qna.domain;
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    public static final Answer A3 = new Answer(UserTest.SANJIGI, QuestionTest.Q3, "testContents");
+    public static final Answer A4 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q3, "testContents");
+
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,0 +1,41 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import qna.NotFoundException;
+
+@DataJpaTest
+class QuestionRepositoryTest {
+
+    @Autowired
+    QuestionRepository questionRepository;
+
+    @Test
+    @DisplayName("삭제되지 않은 question 리스트를 반환한다.")
+    void find_not_deleted_question() {
+        questionRepository.saveAll(Arrays.asList(QuestionTest.Q1, QuestionTest.Q2));
+        List<Question> questions = questionRepository.findByDeletedFalse();
+        for (Question question : questions) {
+            assertThat(question.isDeleted()).isFalse();
+        }
+    }
+
+
+    @Test
+    @DisplayName("questionId를 이용하여 삭제되지 않은 question을 반환한다.")
+    void find_not_deleted_question_with_question_id() {
+        Question requestedQuestion = questionRepository.save(QuestionTest.Q1);
+        Question foundQuestion = questionRepository
+            .findByIdAndDeletedFalse(requestedQuestion.getId())
+            .orElseThrow(NotFoundException::new);
+        assertThat(requestedQuestion.equals(foundQuestion)).isTrue();
+
+    }
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -3,4 +3,6 @@ package qna.domain;
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+    public static final Question Q3 = new Question(1L,"title2", "contents2").writeBy(UserTest.SANJIGI);
+
 }

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -1,0 +1,27 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import qna.NotFoundException;
+
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("userId를 올바른 user를 찾는다.")
+    void find_user_with_user_id() {
+        User requestedUser = userRepository.save(UserTest.JAVAJIGI);
+        User foundUser = userRepository.findByUserId(requestedUser.getUserId())
+            .orElseThrow(NotFoundException::new);
+        assertThat(foundUser.equals(requestedUser)).isTrue();
+    }
+
+}

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import qna.domain.Answer;
 import qna.CannotDeleteException;
 import qna.domain.*;
 


### PR DESCRIPTION
JPA 미션 2단계 연관관계를 구현하였습니다!

✔️ answer->question, answer->user, question->user, deleteHistory->user의 연관관계를 구현하였습니다!
✔️ User의 속성이던 name, userId, password, Email을 원시타입을 감싸는 Embeddable타입의 객체로 꺼내고 이들을 포함하는 Embeddable타입의 UserInfo 객체를 User가 사용하도록 적용하였습니다!