### PR TITLE
Feat: 질문삭제하기 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -9,11 +9,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import java.util.Objects;
-import qna.domain.User;
 
 @Entity
 public class Answer extends BaseTimeEntity {
@@ -56,8 +56,19 @@ public class Answer extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public boolean isOwner(User writer) {
-        return this.writer.equals(writer.getId());
+    public void delete(User loginUser) throws CannotDeleteException {
+        checkAuthority(loginUser);
+        setDeleted(true);
+    }
+
+    private void checkAuthority(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+    }
+
+    private boolean isOwner(User writer) {
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -72,10 +83,6 @@ public class Answer extends BaseTimeEntity {
         return writer;
     }
 
-    public Long getWriterId() {
-        return writer.getId();
-    }
-
     public Question getQuestion() {
         return question;
     }
@@ -84,7 +91,7 @@ public class Answer extends BaseTimeEntity {
         return deleted;
     }
 
-    public void setDeleted(boolean deleted) {
+    private void setDeleted(boolean deleted) {
         this.deleted = deleted;
     }
 

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,36 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DeleteHistories {
+
+    private List<DeleteHistory> deleteHistories = new ArrayList<>();
+
+    public DeleteHistories(Question question, List<Answer> answers) {
+        setDeleteHistories(question, answers);
+    }
+
+    private void setDeleteHistories(Question question, List<Answer> answers) {
+        addQuestionDeleteHistory(question);
+        answers.forEach(this::addAnswerDeleteHistory);
+    }
+
+    private void addQuestionDeleteHistory(Question question) {
+        deleteHistories.add(
+            new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(),
+                LocalDateTime.now()));
+    }
+
+    private void addAnswerDeleteHistory(Answer answer) {
+        deleteHistories.add(
+            new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(),
+                LocalDateTime.now()));
+    }
+
+    public List<DeleteHistory> getDeleteHistories() {
+        return Collections.unmodifiableList(deleteHistories);
+    }
+}

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -38,28 +38,7 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(
-            new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(),
-                LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(),
-                    LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        DeleteHistories deleteHistories = question.delete(loginUser);
+        deleteHistoryService.saveAll(deleteHistories.getDeleteHistories());
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,9 +1,33 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
 public class AnswerTest {
+
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
     public static final Answer A3 = new Answer(UserTest.SANJIGI, QuestionTest.Q3, "testContents");
     public static final Answer A4 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q3, "testContents");
+
+    @Test
+    @DisplayName("자신이 작성한 답변을 삭제상태로 변경한다.")
+    void delete_answer() throws CannotDeleteException {
+        assertThat(A1.isDeleted()).isFalse();
+        A1.delete(UserTest.JAVAJIGI);
+        assertThat(A1.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("본인이 작성하지 않은 답변은 삭제할 수 없다.")
+    void answer_by_other_writers_not_deletable() {
+        assertThatThrownBy(() -> A2.delete(UserTest.JAVAJIGI))
+            .isInstanceOf(CannotDeleteException.class);
+    }
+
 
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,8 +1,53 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
 public class QuestionTest {
+
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
-    public static final Question Q3 = new Question(1L,"title2", "contents2").writeBy(UserTest.SANJIGI);
+    public static final Question Q3 = new Question(1L, "title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Test
+    @DisplayName("자신이 작성한 답변만 존재하는 경우 자신이 작성한 질문을 삭제상태로 변경한다.")
+    void delete_question() throws CannotDeleteException {
+        //given
+        Answer answer = AnswerTest.A1;
+        Q1.addAnswer(answer);
+        assertThat(Q1.isDeleted()).isFalse();
+
+        //when
+        DeleteHistories deleteHistories = Q1.delete(UserTest.JAVAJIGI);
+
+        //then
+        assertThat(answer.isDeleted()).isTrue();
+        assertThat(Q1.isDeleted()).isTrue();
+        assertThat(deleteHistories.getDeleteHistories().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("자신이 아닌 다른 답변자가 존재하는 경우 자신이 작성한 질문을 삭제할 수 없다.")
+    void question_with_answer_by_other_writer_not_deletable() {
+        //given
+        Answer answer = AnswerTest.A4;
+        Q2.addAnswer(answer);
+        assertThat(Q2.isDeleted()).isFalse();
+
+        //when
+        assertThatThrownBy(() -> Q2.delete(UserTest.SANJIGI))
+            .isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 작성하지 않은 질문은 삭제할 수 없다.")
+    void answer_by_other_writers_not_deletable() {
+        assertThatThrownBy(() -> Q3.delete(UserTest.JAVAJIGI))
+            .isInstanceOf(CannotDeleteException.class);
+    }
 
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -22,11 +22,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QnaServiceTest {
-    @Mock
-    private QuestionRepository questionRepository;
 
     @Mock
-    private AnswerRepository answerRepository;
+    private QuestionRepository questionRepository;
 
     @Mock
     private DeleteHistoryService deleteHistoryService;
@@ -46,8 +44,8 @@ class QnaServiceTest {
 
     @Test
     public void delete_성공() throws Exception {
-        when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        when(questionRepository.findByIdAndDeletedFalse(question.getId()))
+            .thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -58,16 +56,17 @@ class QnaServiceTest {
 
     @Test
     public void delete_다른_사람이_쓴_글() throws Exception {
-        when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(questionRepository.findByIdAndDeletedFalse(question.getId()))
+            .thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.SANJIGI, question.getId()))
-                .isInstanceOf(CannotDeleteException.class);
+            .isInstanceOf(CannotDeleteException.class);
     }
 
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
-        when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        when(questionRepository.findByIdAndDeletedFalse(question.getId()))
+            .thenReturn(Optional.of(question));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -81,17 +80,19 @@ class QnaServiceTest {
         Answer answer2 = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
         question.addAnswer(answer2);
 
-        when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
+        when(questionRepository.findByIdAndDeletedFalse(question.getId()))
+            .thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
-                .isInstanceOf(CannotDeleteException.class);
+            .isInstanceOf(CannotDeleteException.class);
     }
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+            new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(),
+                LocalDateTime.now()),
+            new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(),
+                LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
JPA 3단계 질문 삭제하기 리팩토링을 진행하였습니다!

✔️ DeleteHistories 객체를 만들고 question.delete()메소드 사용시 이를 활용하여 반환하도록 하였습니다.
✔️ Question-Answer의 관계를 양방향으로 맺도록 하여 repository에서 answers를 조회하지 않고 question.delete()메소드 사용시 answers중 삭제되지 않은 답변에 대해서 삭제를 진행하도록 구현하였습니다. 
✔️ Question, Answer 도메인 계층에 구현된 삭제 로직을 테스트하도록 QuestionTest, AnswerTest를 작성하였습니다. 
