### PR TITLE
2단계 - 연관 관계 매핑 리뷰 요청

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ alter table question
   - [x] Answer - Question
   - [x] Answer - User
   - [ ] DeleteHistory - User
-  - [ ] Question - User
+  - [x] Question - User
 - [ ] 리포지토리 테스트 작성
   - [x] Answer - Question
   - [x] Answer - User

--- a/README.md
+++ b/README.md
@@ -106,13 +106,14 @@ alter table question
 #### 구현 기능
 - [ ] 연관 관계 매핑
   - [x] Answer - Question
-  - [ ] Answer - User
+  - [x] Answer - User
   - [ ] DeleteHistory - User
   - [ ] Question - User
 - [ ] 리포지토리 테스트 작성
   - [x] Answer - Question
-  - [ ] Answer - User
+  - [x] Answer - User
   - [ ] DeleteHistory - User
   - [ ] Question - User
 - [ ] 도메인 테스트 작성
-  - [x] Answer
+  - [x] Answer - Question
+  - [x] Answer - User

--- a/README.md
+++ b/README.md
@@ -105,13 +105,14 @@ alter table question
 
 #### 구현 기능
 - [ ] 연관 관계 매핑
-  - [ ] Answer - Question
+  - [x] Answer - Question
   - [ ] Answer - User
   - [ ] DeleteHistory - User
   - [ ] Question - User
 - [ ] 리포지토리 테스트 작성
-  - [ ] Answer - Question
+  - [x] Answer - Question
   - [ ] Answer - User
   - [ ] DeleteHistory - User
   - [ ] Question - User
 - [ ] 도메인 테스트 작성
+  - [x] Answer

--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ alter table question
 ```
 
 #### 구현 기능
-- [ ] 연관 관계 매핑
+- [x] 연관 관계 매핑
   - [x] Answer - Question
   - [x] Answer - User
-  - [ ] DeleteHistory - User
+  - [x] DeleteHistory - User
   - [x] Question - User
-- [ ] 리포지토리 테스트 작성
+- [x] 리포지토리 테스트 작성
   - [x] Answer - Question
   - [x] Answer - User
-  - [ ] DeleteHistory - User
-  - [ ] Question - User
-- [ ] 도메인 테스트 작성
+  - [x] DeleteHistory - User
+  - [x] Question - User
+- [x] 도메인 테스트 작성
   - [x] Answer - Question
   - [x] Answer - User
+  - [x] DeleteHistory - User
+  - [x] Question - User

--- a/README.md
+++ b/README.md
@@ -74,3 +74,44 @@ alter table user
   - [x] DeleteHistory
   - [x] Question
   - [x] User
+
+---
+
+### 2단계 - 연관 관계 매핑
+#### 요구사항
+* 객체의 참조와 테이블의 외래 키를 매핑해서 객체에서는 참조를 사용하고 테이블에서는 외래 키를 사용할 수 있도록 한다.
+* 아래의 DDL을 보고 유추한다.
+```roomsql
+alter table answer
+    add constraint fk_answer_to_question
+        foreign key (question_id)
+            references question
+
+alter table answer
+    add constraint fk_answer_writer
+        foreign key (writer_id)
+            references user
+
+alter table delete_history
+    add constraint fk_delete_history_to_user
+        foreign key (deleted_by_id)
+            references user
+
+alter table question
+    add constraint fk_question_writer
+        foreign key (writer_id)
+            references user
+```
+
+#### 구현 기능
+- [ ] 연관 관계 매핑
+  - [ ] Answer - Question
+  - [ ] Answer - User
+  - [ ] DeleteHistory - User
+  - [ ] Question - User
+- [ ] 리포지토리 테스트 작성
+  - [ ] Answer - Question
+  - [ ] Answer - User
+  - [ ] DeleteHistory - User
+  - [ ] Question - User
+- [ ] 도메인 테스트 작성

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -11,8 +11,9 @@ import java.util.Objects;
 public class Answer extends BaseEntity {
     @Column(name = "writer_id")
     private Long writerId;
-    @Column(name = "question_id")
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
     @Lob
     @Column(name = "contents", columnDefinition = "CLOB")
     private String contents;
@@ -37,7 +38,7 @@ public class Answer extends BaseEntity {
         }
 
         this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.question = question;
         this.contents = contents;
     }
 
@@ -46,7 +47,7 @@ public class Answer extends BaseEntity {
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
@@ -57,8 +58,8 @@ public class Answer extends BaseEntity {
         return this.writerId;
     }
 
-    public Long getQuestionId() {
-        return this.questionId;
+    public Question getQuestion() {
+        return this.question;
     }
 
     public boolean isDeleted() {
@@ -87,7 +88,7 @@ public class Answer extends BaseEntity {
         return "Answer{" +
                 "id=" + this.id +
                 ", writerId=" + this.writerId +
-                ", questionId=" + this.questionId +
+                ", question=" + this.question +
                 ", contents='" + this.contents + '\'' +
                 ", deleted=" + this.deleted +
                 '}';

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -9,8 +9,9 @@ import java.util.Objects;
 @Entity
 @Table(name = "answer")
 public class Answer extends BaseEntity {
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
@@ -37,13 +38,13 @@ public class Answer extends BaseEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
+        this.writer = writer;
         this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -54,8 +55,8 @@ public class Answer extends BaseEntity {
         return this.id;
     }
 
-    public Long getWriterId() {
-        return this.writerId;
+    public User getWriter() {
+        return this.writer;
     }
 
     public Question getQuestion() {
@@ -87,7 +88,7 @@ public class Answer extends BaseEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + this.id +
-                ", writerId=" + this.writerId +
+                ", writer=" + this.writer +
                 ", question=" + this.question +
                 ", contents='" + this.contents + '\'' +
                 ", deleted=" + this.deleted +

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -15,17 +15,18 @@ public class DeleteHistory {
     private ContentType contentType;
     @Column(name = "content_id")
     private Long contentId;
-    @Column(name = "deleted_by_id")
-    private Long deletedById;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
     @Column(name = "create_date")
     protected LocalDateTime createDate;
 
     protected DeleteHistory() {}
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -41,12 +42,12 @@ public class DeleteHistory {
         return Objects.equals(this.id, that.id) &&
                 this.contentType == that.contentType &&
                 Objects.equals(this.contentId, that.contentId) &&
-                Objects.equals(this.deletedById, that.deletedById);
+                Objects.equals(this.deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.id, this.contentType, this.contentId, this.deletedById);
+        return Objects.hash(this.id, this.contentType, this.contentId, this.deletedBy);
     }
 
     @Override
@@ -55,7 +56,7 @@ public class DeleteHistory {
                 "id=" + this.id +
                 ", contentType=" + this.contentType +
                 ", contentId=" + this.contentId +
-                ", deletedById=" + this.deletedById +
+                ", deletedBy=" + this.deletedBy +
                 ", createDate=" + this.createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,5 +1,7 @@
 package qna.domain;
 
+import qna.UnAuthorizedException;
+
 import javax.persistence.*;
 import java.util.Objects;
 
@@ -11,8 +13,9 @@ public class Question extends BaseEntity {
     @Lob
     @Column(name = "contents", columnDefinition = "CLOB")
     private String contents;
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
     @Column(name = "deleted", nullable = false)
     private boolean deleted = false;
 
@@ -29,12 +32,16 @@ public class Question extends BaseEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        if (Objects.isNull(writer)) {
+            throw new UnAuthorizedException();
+        }
+
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -45,8 +52,8 @@ public class Question extends BaseEntity {
         return this.id;
     }
 
-    public Long getWriterId() {
-        return this.writerId;
+    public User getWriter() {
+        return this.writer;
     }
 
     public boolean isDeleted() {
@@ -76,7 +83,7 @@ public class Question extends BaseEntity {
                 "id=" + this.id +
                 ", title='" + this.title + '\'' +
                 ", contents='" + this.contents + '\'' +
-                ", writerId=" + this.writerId +
+                ", writer=" + this.writer +
                 ", deleted=" + this.deleted +
                 '}';
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -51,7 +51,7 @@ public class QnaService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,7 +48,7 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,14 +14,25 @@ import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 class AnswerRepositoryTest {
+    private Answer answer1;
+    private Answer answer2;
     @Autowired
     private AnswerRepository answerRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @BeforeEach
+    void setUp() {
+        Question question = questionRepository.save(QuestionTest.Q1);
+        answer1 = new Answer(UserTest.JAVAJIGI, question, "Answers Contents1");
+        answer2 = new Answer(UserTest.SANJIGI, question, "Answers Contents2");
+    }
 
     @DisplayName("Answer 생성")
     @Test
     void teat_save() {
         //given & when
-        Answer savedAnswer = answerRepository.save(AnswerTest.A1);
+        Answer savedAnswer = answerRepository.save(this.answer1);
         Optional<Answer> findAnswer = answerRepository.findById(savedAnswer.getId());
         //then
         assertAll(
@@ -33,11 +45,11 @@ class AnswerRepositoryTest {
     @Test
     void teat_findByQuestionIdAndDeletedFalse() {
         //given
-        AnswerTest.A1.setDeleted(true);
-        Answer deletedAnswer = answerRepository.save(AnswerTest.A1);
-        Answer savedAnswer = answerRepository.save(AnswerTest.A2);
+        this.answer1.setDeleted(true);
+        Answer deletedAnswer = answerRepository.save(this.answer1);
+        Answer savedAnswer = answerRepository.save(this.answer2);
         //when
-        List<Answer> findAnswers = answerRepository.findByQuestionIdAndDeletedFalse(deletedAnswer.getQuestionId());
+        List<Answer> findAnswers = answerRepository.findByQuestionIdAndDeletedFalse(deletedAnswer.getQuestion().getId());
         //then
         assertAll(
                 () -> assertThat(findAnswers).hasSize(1),
@@ -49,9 +61,9 @@ class AnswerRepositoryTest {
     @Test
     void teat_findByIdAndDeletedFalse() {
         //given
-        AnswerTest.A1.setDeleted(true);
-        Answer deletedAnswer = answerRepository.save(AnswerTest.A1);
-        Answer savedAnswer = answerRepository.save(AnswerTest.A2);
+        this.answer1.setDeleted(true);
+        Answer deletedAnswer = answerRepository.save(answer1);
+        Answer savedAnswer = answerRepository.save(answer2);
         //when
         Optional<Answer> findAnswer1 = answerRepository.findByIdAndDeletedFalse(deletedAnswer.getId());
         Optional<Answer> findAnswer2 = answerRepository.findByIdAndDeletedFalse(savedAnswer.getId());

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -27,9 +27,10 @@ class AnswerRepositoryTest {
     void setUp() {
         User javajigi = userRepository.save(UserTest.JAVAJIGI);
         User sanjigi = userRepository.save(UserTest.SANJIGI);
-        Question question = questionRepository.save(QuestionTest.Q1);
-        answer1 = new Answer(javajigi, question, "Answers Contents1");
-        answer2 = new Answer(sanjigi, question, "Answers Contents2");
+        Question question = new Question("title", "contents").writeBy(javajigi);
+        questionRepository.save(question);
+        this.answer1 = new Answer(javajigi, question, "Answers Contents1");
+        this.answer2 = new Answer(sanjigi, question, "Answers Contents2");
     }
 
     @DisplayName("Answer 생성")

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -20,12 +20,16 @@ class AnswerRepositoryTest {
     private AnswerRepository answerRepository;
     @Autowired
     private QuestionRepository questionRepository;
+    @Autowired
+    private UserRepository userRepository;
 
     @BeforeEach
     void setUp() {
+        User javajigi = userRepository.save(UserTest.JAVAJIGI);
+        User sanjigi = userRepository.save(UserTest.SANJIGI);
         Question question = questionRepository.save(QuestionTest.Q1);
-        answer1 = new Answer(UserTest.JAVAJIGI, question, "Answers Contents1");
-        answer2 = new Answer(UserTest.SANJIGI, question, "Answers Contents2");
+        answer1 = new Answer(javajigi, question, "Answers Contents1");
+        answer2 = new Answer(sanjigi, question, "Answers Contents2");
     }
 
     @DisplayName("Answer 생성")

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -21,7 +21,7 @@ public class AnswerTest {
         assertThat(answer).isNotNull();
     }
 
-    @DisplayName("Answer 도메인 생성 시 Question 이 null 이면 NotFoundException")
+    @DisplayName("Answer 도메인 생성 시 Question 이 null 이면 예외 처리")
     @Test
     void test_null_question() {
         //given & when & then
@@ -29,7 +29,7 @@ public class AnswerTest {
                 .isInstanceOf(NotFoundException.class);
     }
 
-    @DisplayName("Answer 도메인 생성 시 User 가 null 이면 UnAuthorizedException")
+    @DisplayName("Answer 도메인 생성 시 User 가 null 이면 예외 처리")
     @Test
     void test_null_user() {
         //given & when & then

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -21,7 +21,7 @@ public class AnswerTest {
         assertThat(answer).isNotNull();
     }
 
-    @DisplayName("Answer 도메인 생성 시 Question 이 null 이면 예외 처리")
+    @DisplayName("Question 이 없을 경우 Answer 생성 불가")
     @Test
     void test_null_question() {
         //given & when & then
@@ -29,7 +29,7 @@ public class AnswerTest {
                 .isInstanceOf(NotFoundException.class);
     }
 
-    @DisplayName("Answer 도메인 생성 시 User 가 null 이면 예외 처리")
+    @DisplayName("User 가 없으면 Answer 생성 불가")
     @Test
     void test_null_user() {
         //given & when & then

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -3,6 +3,7 @@ package qna.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import qna.NotFoundException;
+import qna.UnAuthorizedException;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -26,6 +27,14 @@ public class AnswerTest {
         //given & when & then
         assertThatThrownBy(() -> new Answer(UserTest.JAVAJIGI, null, "Answers Contents"))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("Answer 도메인 생성 시 User 가 null 이면 UnAuthorizedException")
+    @Test
+    void test_null_user() {
+        //given & when & then
+        assertThatThrownBy(() -> new Answer(null, QuestionTest.Q1, "Answers Contents"))
+                .isInstanceOf(UnAuthorizedException.class);
     }
 
     @DisplayName("소유자 확인")

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -2,13 +2,31 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.NotFoundException;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @DisplayName("Answer 도메인 생성")
+    @Test
+    void test_new() {
+        //given & when
+        Answer answer = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents");
+        //then
+        assertThat(answer).isNotNull();
+    }
+
+    @DisplayName("Answer 도메인 생성 시 Question 이 null 이면 NotFoundException")
+    @Test
+    void test_null_question() {
+        //given & when & then
+        assertThatThrownBy(() -> new Answer(UserTest.JAVAJIGI, null, "Answers Contents"))
+                .isInstanceOf(NotFoundException.class);
+    }
 
     @DisplayName("소유자 확인")
     @Test
@@ -16,7 +34,7 @@ public class AnswerTest {
         //given & when & then
         assertAll(
                 () -> assertThat(A1.isOwner(UserTest.JAVAJIGI)).isTrue(),
-                () -> assertThat(A1.isOwner(UserTest.SANJIGI)).isFalse()
+                () -> assertThat(A2.isOwner(UserTest.SANJIGI)).isTrue()
         );
     }
 }

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -27,14 +27,14 @@ class DeleteHistoryRepositoryTest {
         User javajigi = userRepository.save(UserTest.JAVAJIGI);
         Question question = new Question("title", "contents").writeBy(javajigi);
         questionRepository.save(question);
-        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), javajigi.getId(), LocalDateTime.now());
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), javajigi, LocalDateTime.now());
         //when
-        DeleteHistory savedDeleteHistory = deleteHistoryRepository.save(deleteHistory);
-        Optional<DeleteHistory> findDeleteHistory = deleteHistoryRepository.findById(savedDeleteHistory.getId());
+        deleteHistoryRepository.save(deleteHistory);
+        Optional<DeleteHistory> findDeleteHistory = deleteHistoryRepository.findById(deleteHistory.getId());
         //then
         assertAll(
                 () -> assertThat(findDeleteHistory.isPresent()).isTrue(),
-                () -> assertThat(savedDeleteHistory.equals(findDeleteHistory.get())).isTrue()
+                () -> assertThat(deleteHistory.equals(findDeleteHistory.get())).isTrue()
         );
     }
 }

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -24,9 +24,10 @@ class DeleteHistoryRepositoryTest {
     @Test
     void teat_save() {
         //given
-        Question question = questionRepository.save(QuestionTest.Q1);
-        User user = userRepository.save(UserTest.JAVAJIGI);
-        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), user.getId(), LocalDateTime.now());
+        User javajigi = userRepository.save(UserTest.JAVAJIGI);
+        Question question = new Question("title", "contents").writeBy(javajigi);
+        questionRepository.save(question);
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), javajigi.getId(), LocalDateTime.now());
         //when
         DeleteHistory savedDeleteHistory = deleteHistoryRepository.save(deleteHistory);
         Optional<DeleteHistory> findDeleteHistory = deleteHistoryRepository.findById(savedDeleteHistory.getId());

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,19 @@
+package qna.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteHistoryTest {
+    @DisplayName("Answer 도메인 생성")
+    @Test
+    void test_new() {
+        //given & when
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, UserTest.JAVAJIGI, LocalDateTime.now());
+        //then
+        assertThat(deleteHistory).isNotNull();
+    }
+}

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DeleteHistoryTest {
-    @DisplayName("Answer 도메인 생성")
+    @DisplayName("DeleteHistory 도메인 생성")
     @Test
     void test_new() {
         //given & when

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,19 +9,31 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class QuestionRepositoryTest {
+    private Question question1;
+    private Question question2;
     @Autowired
     private QuestionRepository questionRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User javajigi = userRepository.save(UserTest.JAVAJIGI);
+        User sanjigi = userRepository.save(UserTest.SANJIGI);
+        this.question1 = new Question("title1", "contents1").writeBy(javajigi);
+        this.question2 = new Question("title2", "contents2").writeBy(sanjigi);
+    }
 
     @DisplayName("Question 생성")
     @Test
     void teat_save() {
         //given & when
-        Question savedQuestion = questionRepository.save(QuestionTest.Q1);
+        Question savedQuestion = questionRepository.save(this.question1);
         Optional<Question> findQuestion = questionRepository.findById(savedQuestion.getId());
         //then
         assertAll(
@@ -33,9 +46,9 @@ class QuestionRepositoryTest {
     @Test
     void teat_findByDeletedFalse() {
         //given
-        QuestionTest.Q1.setDeleted(true);
-        questionRepository.save(QuestionTest.Q1);
-        Question savedQuestion = questionRepository.save(QuestionTest.Q2);
+        this.question1.setDeleted(true);
+        questionRepository.save(this.question1);
+        Question savedQuestion = questionRepository.save(this.question2);
         //when
         List<Question> findQuestions = questionRepository.findByDeletedFalse();
         //then
@@ -49,9 +62,9 @@ class QuestionRepositoryTest {
     @Test
     void teat_findByIdAndDeletedFalse() {
         //given
-        QuestionTest.Q1.setDeleted(true);
-        Question deletedQuestion = questionRepository.save(QuestionTest.Q1);
-        Question savedQuestion = questionRepository.save(QuestionTest.Q2);
+        this.question1.setDeleted(true);
+        Question deletedQuestion = questionRepository.save(this.question1);
+        Question savedQuestion = questionRepository.save(this.question2);
         //when
         Optional<Question> findDeletedQuestions = questionRepository.findByIdAndDeletedFalse(deletedQuestion.getId());
         Optional<Question> findSavedQuestions = questionRepository.findByIdAndDeletedFalse(savedQuestion.getId());

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -2,13 +2,32 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.UnAuthorizedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("Question 도메인 생성")
+    @Test
+    void test_new() {
+        //given & when
+        Question question = new Question("title", "contents").writeBy(UserTest.JAVAJIGI);
+        //then
+        assertThat(question).isNotNull();
+    }
+
+    @DisplayName("Question 도메인 생성 후 작성자(writer)가 null 이면 UnAuthorizedException")
+    @Test
+    void test_null_user() {
+        //given & when & then
+        assertThatThrownBy(() -> new Question("title", "contents").writeBy(null))
+                .isInstanceOf(UnAuthorizedException.class);
+    }
 
     @DisplayName("소유자 확인")
     @Test
@@ -16,7 +35,7 @@ public class QuestionTest {
         //given & when & then
         assertAll(
                 () -> assertThat(Q1.isOwner(UserTest.JAVAJIGI)).isTrue(),
-                () -> assertThat(Q1.isOwner(UserTest.SANJIGI)).isFalse()
+                () -> assertThat(Q2.isOwner(UserTest.SANJIGI)).isTrue()
         );
     }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -21,7 +21,7 @@ public class QuestionTest {
         assertThat(question).isNotNull();
     }
 
-    @DisplayName("Question 도메인 생성 후 작성자(writer)가 null 이면 UnAuthorizedException")
+    @DisplayName("Question 도메인 생성 후 작성자(writer)가 null 이면 예외 처리")
     @Test
     void test_null_user() {
         //given & when & then

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -21,7 +21,7 @@ public class QuestionTest {
         assertThat(question).isNotNull();
     }
 
-    @DisplayName("Question 도메인 생성 후 작성자(writer)가 null 이면 예외 처리")
+    @DisplayName("Question 의 작성자(writer)가 없으면 오류")
     @Test
     void test_null_user() {
         //given & when & then

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -29,7 +29,7 @@ public class UserTest {
         assertThat(JAVAJIGI.equalsNameAndEmail(SANJIGI)).isTrue();
     }
 
-    @DisplayName("업데이트 시 로그인 사용자가 동일하지 않을 경우 예외 처리")
+    @DisplayName("업데이트 시 로그인 사용자가 동일하지 않을 경우 오류")
     @Test
     void test_not_equals_login_user() {
         //given & when & then
@@ -37,7 +37,7 @@ public class UserTest {
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
-    @DisplayName("업데이트 시 타겟 사용자와 비밀번호가 동일하지 않을 경우 예외 처리")
+    @DisplayName("업데이트 시 타겟 사용자와 비밀번호가 동일하지 않을 경우 오류")
     @Test
     void test_not_equals_password_target_user() {
         //given & when & then

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -29,7 +29,7 @@ public class UserTest {
         assertThat(JAVAJIGI.equalsNameAndEmail(SANJIGI)).isTrue();
     }
 
-    @DisplayName("업데이트 시 로그인 사용자가 동일하지 않을 경우 UnAuthorizedException")
+    @DisplayName("업데이트 시 로그인 사용자가 동일하지 않을 경우 예외 처리")
     @Test
     void test_not_equals_login_user() {
         //given & when & then
@@ -37,7 +37,7 @@ public class UserTest {
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
-    @DisplayName("업데이트 시 타겟 사용자와 비밀번호가 동일하지 않을 경우 UnAuthorizedException")
+    @DisplayName("업데이트 시 타겟 사용자와 비밀번호가 동일하지 않을 경우 예외 처리")
     @Test
     void test_not_equals_password_target_user() {
         //given & when & then

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -2,6 +2,7 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.UnAuthorizedException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
@@ -10,6 +11,15 @@ public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
 
+    @DisplayName("Answer 도메인 생성")
+    @Test
+    void test_new() {
+        //given & when
+        User newUser = new User(3L, "new", "password", "name", "new@slipp.net");
+        //then
+        assertThat(newUser).isNotNull();
+    }
+
     @DisplayName("name, email 업데이트 후 변경 확인")
     @Test
     void test_update_equalsNameAndEmail() {
@@ -17,6 +27,23 @@ public class UserTest {
         JAVAJIGI.update(JAVAJIGI, SANJIGI);
         //when & then
         assertThat(JAVAJIGI.equalsNameAndEmail(SANJIGI)).isTrue();
+    }
+
+    @DisplayName("업데이트 시 로그인 사용자가 동일하지 않을 경우 UnAuthorizedException")
+    @Test
+    void test_not_equals_login_user() {
+        //given & when & then
+        assertThatThrownBy(() -> JAVAJIGI.update(SANJIGI, SANJIGI))
+                .isInstanceOf(UnAuthorizedException.class);
+    }
+
+    @DisplayName("업데이트 시 타겟 사용자와 비밀번호가 동일하지 않을 경우 UnAuthorizedException")
+    @Test
+    void test_not_equals_password_target_user() {
+        //given & when & then
+        User target = new User(4L, "target", "targetPassword", "targetName", "target@slipp.net");
+        assertThatThrownBy(() -> JAVAJIGI.update(JAVAJIGI, target))
+                .isInstanceOf(UnAuthorizedException.class);
     }
 
     @DisplayName("GuestUser 확인")

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,7 +89,7 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
                 new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -90,7 +90,7 @@ class QnaServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,3 +5,5 @@ spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+spring.output.ansi.enabled=always
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
안녕하세요. 이슬님!
2단계 연관 관계 매핑 과제 리뷰 요청 드립니다.

진행하면서 도메인 객체 간의 연관 관계 구조에 대한 많은 생각을 할 수 있었던 과제였습니다!
JoinColumn 부분은 생략하면 전략에 따라 외래 키를 매핑하긴 하지만 학습한다는 생각에 추가하게 되었습니다.

지난 1단계에서 추가로 남겨 주신 코멘트의 (`트랜잭션이 종료되기 전에 직접 flush 를 호출하면 어떤 차이가 있을까요?`)
관련 내용 리서치 해보니 엔티티 매니저가 쓰기 지연 저장소에 존재하는 영속성 컨텍스트를 트랜잭션이 커밋하기 전에 flush 자동으로 호출하여 데이터베이스와 동기화를 처리하는 과정이 이미 수행되고 있네요. 제가 생각하는 부분이 확실한지 좀 더 알아봐야겠지만.. 제가 이전에 구현했던 코드에서는 직접 flush를 호출함으로 인해 동일한 동작이 중복으로 실행된다고 알게 되었습니다.
데이터베이스와 동기화가 필요한 시점에 적절히 사용하는 것이 더 좋을 거 같다는 생각이 듭니다.😄
스스로 찾아보고 생각할 수 있도록 조언 해주셔서 감사합니다!🙇

이번 리뷰에서도 유익한 조언 부탁 드립니다~ 감사합니다!!