### PR TITLE
2단계 - 연관 관계 매핑에 대한 리뷰 요청드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@
 
 - [X] User → Question 일대다 관계로 참조
 - [X] User → DeleteHistory 일대다 관계로 참조
+- [X] User → Answer 일대다 관계로 참조
+- [X] Question → Answer 일대다 관계로 참조

--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@
 - [X] Answer(의존 관계 주인) → User 다대일 관계로 참조
 - [X] Answer(의존 관계 주인) → Question 다대일 관계로 참조
 - [X] DeleteHistory(의존 관계 주인) → User 다대일 관계로 참조
-- [X] Question → Answer 일대다 관계로 참조

--- a/README.md
+++ b/README.md
@@ -29,8 +29,4 @@
 - [X] Answer(의존 관계 주인) → User 다대일 관계로 참조
 - [X] Answer(의존 관계 주인) → Question 다대일 관계로 참조
 - [X] DeleteHistory(의존 관계 주인) → User 다대일 관계로 참조
-
-- [X] User → Question 일대다 관계로 참조
-- [X] User → DeleteHistory 일대다 관계로 참조
-- [X] User → Answer 일대다 관계로 참조
 - [X] Question → Answer 일대다 관계로 참조

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@
 - [X] Question 관련 CRUD 기능을 제공하는 QuestionRepository 클래스
 - [X] Answer 관련 CRUD 기능을 제공하는 AnswerRepository 클래스
 - [X] DeleteHistory 관련 CRUD 기능을 제공하는 DeleteHistoryRepository 클래스
+
+## 2단계 - 연관 관계 매핑
+
+## 기능 목록
+
+- [X] Question(의존 관계 주인) → User 다대일 관계로 참조
+- [X] Answer(의존 관계 주인) → User 다대일 관계로 참조
+- [X] Answer(의존 관계 주인) → Question 다대일 관계로 참조
+- [X] DeleteHistory(의존 관계 주인) → User 다대일 관계로 참조

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@
 - [X] Answer(의존 관계 주인) → User 다대일 관계로 참조
 - [X] Answer(의존 관계 주인) → Question 다대일 관계로 참조
 - [X] DeleteHistory(의존 관계 주인) → User 다대일 관계로 참조
+
+- [X] User → Question 일대다 관계로 참조

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@
 - [X] DeleteHistory(의존 관계 주인) → User 다대일 관계로 참조
 
 - [X] User → Question 일대다 관계로 참조
+- [X] User → DeleteHistory 일대다 관계로 참조

--- a/src/main/java/qna/Application.java
+++ b/src/main/java/qna/Application.java
@@ -2,7 +2,9 @@ package qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import org.hibernate.annotations.SQLDelete;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -9,7 +8,6 @@ import java.util.Objects;
 
 @Entity
 @Table(name = "answer")
-@SQLDelete(sql = "update answer set deleted = true where id = ?")
 public class Answer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -64,7 +64,6 @@ public class Answer extends BaseEntity {
 
     public Answer toQuestion(Question question) {
         this.question = question;
-        question.getAnswers().add(this);
         return this;
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -38,6 +38,26 @@ public class Answer extends BaseEntity {
         this.contents = contents;
     }
 
+    public Answer(User writer, Question question, String contents) {
+        this(null, writer, question, contents);
+    }
+
+    public Answer(Long id, User writer, Question question, String contents) {
+        this.id = id;
+
+        if (Objects.isNull(writer)) {
+            throw new UnAuthorizedException();
+        }
+
+        if (Objects.isNull(question)) {
+            throw new NotFoundException();
+        }
+
+        this.writer = writer;
+        this.question = question;
+        this.contents = contents;
+    }
+
     public boolean isOwner(User writer) {
         return this.writer.equals(writer);
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -17,8 +17,9 @@ public class Answer extends BaseEntity {
     @JoinColumn(name = "writer_id")
     private User writer;
 
-    @Column(name = "question_id")
-    private Long questionId;
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
 
     @Lob
     private String contents;
@@ -44,7 +45,7 @@ public class Answer extends BaseEntity {
         }
 
         this.writer = writer;
-        this.questionId = question.getId();
+        this.question = question;
         this.contents = contents;
     }
 
@@ -53,7 +54,7 @@ public class Answer extends BaseEntity {
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
@@ -72,12 +73,12 @@ public class Answer extends BaseEntity {
         this.writer = writer;
     }
 
-    public Long getQuestionId() {
-        return questionId;
+    public Question getQuestion() {
+        return question;
     }
 
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
+    public void setQuestion(Question question) {
+        this.question = question;
     }
 
     public String getContents() {
@@ -101,7 +102,7 @@ public class Answer extends BaseEntity {
         return "Answer{" +
                 "id=" + id +
                 ", writer=" + writer +
-                ", questionId=" + questionId +
+                ", question=" + question +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -57,6 +57,10 @@ public class Answer extends BaseEntity {
         this.question = question;
     }
 
+    public void updateContents(String contents) {
+        this.contents = contents;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -13,8 +13,9 @@ public class Answer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private User writer;
 
     @Column(name = "question_id")
     private Long questionId;
@@ -42,13 +43,13 @@ public class Answer extends BaseEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
+        this.writer = writer;
         this.questionId = question.getId();
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -63,12 +64,12 @@ public class Answer extends BaseEntity {
         this.id = id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 
     public Long getQuestionId() {
@@ -99,7 +100,7 @@ public class Answer extends BaseEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", questionId=" + questionId +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import jdk.jfr.Name;
 import org.hibernate.annotations.SQLDelete;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -70,7 +70,6 @@ public class Answer extends BaseEntity {
 
     public Answer writeBy(User user) {
         this.writer = user;
-        user.getAnswers().add(this);
         return this;
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -29,6 +29,10 @@ public class Answer extends BaseEntity {
     protected Answer() {
     }
 
+    public Answer(String contents) {
+        this.contents = contents;
+    }
+
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
     }
@@ -53,8 +57,16 @@ public class Answer extends BaseEntity {
         return this.writer.equals(writer);
     }
 
-    public void toQuestion(Question question) {
+    public Answer toQuestion(Question question) {
         this.question = question;
+        question.getAnswers().add(this);
+        return this;
+    }
+
+    public Answer writeBy(User user) {
+        this.writer = user;
+        user.getAnswers().add(this);
+        return this;
     }
 
     public void updateContents(String contents) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -13,11 +13,11 @@ public class Answer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private User writer;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -61,32 +61,16 @@ public class Answer extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public User getWriter() {
         return writer;
-    }
-
-    public void setWriter(User writer) {
-        this.writer = writer;
     }
 
     public Question getQuestion() {
         return question;
     }
 
-    public void setQuestion(Question question) {
-        this.question = question;
-    }
-
     public String getContents() {
         return contents;
-    }
-
-    public void setContents(String contents) {
-        this.contents = contents;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -30,26 +30,11 @@ public class Answer extends BaseEntity {
     }
 
     public Answer(String contents) {
-        this.contents = contents;
+        this(null, contents);
     }
 
-    public Answer(User writer, Question question, String contents) {
-        this(null, writer, question, contents);
-    }
-
-    public Answer(Long id, User writer, Question question, String contents) {
+    public Answer(Long id, String contents) {
         this.id = id;
-
-        if (Objects.isNull(writer)) {
-            throw new UnAuthorizedException();
-        }
-
-        if (Objects.isNull(question)) {
-            throw new NotFoundException();
-        }
-
-        this.writer = writer;
-        this.question = question;
         this.contents = contents;
     }
 

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -18,8 +18,9 @@ public class DeleteHistory {
     @Column(name = "content_id")
     private Long contentId;
 
-    @Column(name = "deleted_by_id")
-    private Long deletedById;
+    @ManyToOne
+    @JoinColumn(name = "deleted_by_id")
+    private User deleteUser;
 
     @Column(name = "create_date")
     private LocalDateTime createDate = LocalDateTime.now();
@@ -27,10 +28,10 @@ public class DeleteHistory {
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deleteUser, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deleteUser = deleteUser;
         this.createDate = createDate;
     }
 
@@ -42,12 +43,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&
                 Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+                Objects.equals(deleteUser, that.deleteUser);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deleteUser, createDate);
     }
 
     @Override
@@ -56,7 +57,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deleteUser=" + deleteUser +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -18,7 +18,7 @@ public class DeleteHistory {
     @Column(name = "content_id")
     private Long contentId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deleted_by_id")
     private User deleteUser;
 

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -36,7 +36,6 @@ public class DeleteHistory {
 
     public DeleteHistory deleteBy(User user) {
         this.deleteUser = user;
-        user.getDeleteHistories().add(this);
         return this;
     }
 

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -28,11 +28,28 @@ public class DeleteHistory {
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, User deleteUser, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deleteUser = deleteUser;
         this.createDate = createDate;
+    }
+
+    public DeleteHistory deleteBy(User user) {
+        this.deleteUser = user;
+        user.getDeleteHistories().add(this);
+        return this;
+    }
+
+    public ContentType getContentType() {
+        return contentType;
+    }
+
+    public Long getContentId() {
+        return contentId;
+    }
+
+    public User getDeleteUser() {
+        return deleteUser;
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -37,7 +37,8 @@ public class Question extends BaseEntity {
     }
 
     public Question writeBy(User user) {
-        setWriter(user);
+        this.writer = user;
+        user.getQuestions().add(this);
         return this;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -17,8 +17,9 @@ public class Question extends BaseEntity {
     @Lob
     private String contents;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private User writer;
 
     private boolean deleted = false;
 
@@ -35,13 +36,13 @@ public class Question extends BaseEntity {
         this.contents = contents;
     }
 
-    public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+    public Question writeBy(User user) {
+        setWriter(user);
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -72,12 +73,12 @@ public class Question extends BaseEntity {
         this.contents = contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 
     public boolean isDeleted() {
@@ -107,7 +108,7 @@ public class Question extends BaseEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -54,32 +54,16 @@ public class Question extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     public String getContents() {
         return contents;
     }
 
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
-
     public User getWriter() {
         return writer;
-    }
-
-    public void setWriter(User writer) {
-        this.writer = writer;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -43,7 +43,6 @@ public class Question extends BaseEntity {
 
     public Question writeBy(User user) {
         this.writer = user;
-        user.getQuestions().add(this);
         return this;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -23,9 +23,6 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "writer_id")
     private User writer;
 
-    @OneToMany(mappedBy = "question")
-    private List<Answer> answers = new ArrayList<>();
-
     private boolean deleted = false;
 
     protected Question() {
@@ -76,10 +73,6 @@ public class Question extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
-    }
-
-    public List<Answer> getAnswers() {
-        return answers;
     }
 
     @Override

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,13 +1,10 @@
 package qna.domain;
 
-import org.hibernate.annotations.SQLDelete;
-
 import javax.persistence.*;
 import java.util.Objects;
 
 @Entity
 @Table(name = "question")
-@SQLDelete(sql = "update question set deleted = true where id = ?")
 public class Question extends BaseEntity {
 
     @Id

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -19,7 +19,7 @@ public class Question extends BaseEntity {
     @Lob
     private String contents;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private User writer;
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,8 @@
 package qna.domain;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -20,6 +22,9 @@ public class Question extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "writer_id")
     private User writer;
+
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers = new ArrayList<>();
 
     private boolean deleted = false;
 
@@ -72,6 +77,10 @@ public class Question extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -28,15 +28,6 @@ public class User extends BaseEntity {
     @Column(length = 50)
     private String email;
 
-    @OneToMany(mappedBy = "writer")
-    List<Question> questions = new ArrayList<>();
-
-    @OneToMany(mappedBy = "writer")
-    List<Answer> answers = new ArrayList<>();
-
-    @OneToMany(mappedBy = "deleteUser")
-    List<DeleteHistory> deleteHistories = new ArrayList<>();
-
     protected User() {
     }
 
@@ -116,18 +107,6 @@ public class User extends BaseEntity {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public List<Question> getQuestions() {
-        return questions;
-    }
-
-    public List<DeleteHistory> getDeleteHistories() {
-        return deleteHistories;
-    }
-
-    public List<Answer> getAnswers() {
-        return answers;
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -3,8 +3,6 @@ package qna.domain;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -3,6 +3,8 @@ package qna.domain;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -25,6 +27,9 @@ public class User extends BaseEntity {
 
     @Column(length = 50)
     private String email;
+
+    @OneToMany(mappedBy = "writer")
+    List<Question> questions = new ArrayList<>();
 
     protected User() {
     }
@@ -113,6 +118,14 @@ public class User extends BaseEntity {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public List<Question> getQuestions() {
+        return questions;
+    }
+
+    public void setQuestions(List<Question> questions) {
+        this.questions = questions;
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -31,6 +31,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "writer")
     List<Question> questions = new ArrayList<>();
 
+    @OneToMany(mappedBy = "deleteUser")
+    List<DeleteHistory> deleteHistories = new ArrayList<>();
+
     protected User() {
     }
 
@@ -84,24 +87,12 @@ public class User extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getUserId() {
         return userId;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
     public String getPassword() {
         return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 
     public String getName() {
@@ -124,8 +115,8 @@ public class User extends BaseEntity {
         return questions;
     }
 
-    public void setQuestions(List<Question> questions) {
-        this.questions = questions;
+    public List<DeleteHistory> getDeleteHistories() {
+        return deleteHistories;
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -31,6 +31,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "writer")
     List<Question> questions = new ArrayList<>();
 
+    @OneToMany(mappedBy = "writer")
+    List<Answer> answers = new ArrayList<>();
+
     @OneToMany(mappedBy = "deleteUser")
     List<DeleteHistory> deleteHistories = new ArrayList<>();
 
@@ -47,6 +50,10 @@ public class User extends BaseEntity {
         this.password = password;
         this.name = name;
         this.email = email;
+    }
+
+    public void addAnswer(Answer answer) {
+        answer.writeBy(this);
     }
 
     public void update(User loginUser, User target) {
@@ -117,6 +124,10 @@ public class User extends BaseEntity {
 
     public List<DeleteHistory> getDeleteHistories() {
         return deleteHistories;
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
     }
 
     @Override

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,7 +48,7 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -51,7 +51,7 @@ public class QnaService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, LocalDateTime.now()).deleteBy(question.getWriter()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), LocalDateTime.now()).deleteBy(answer.getWriter()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -64,13 +64,9 @@ public class AnswerRepositoryTest {
     @Test
     void 댓글_삭제() {
         final Answer answer = answerRepository.save(new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "댓글 작성"));
-        final Optional<Answer> find = answerRepository.findByIdAndDeletedFalse(answer.getId());
-        assertThat(find).isNotEmpty();
-
         answerRepository.delete(answer);
-        answerRepository.flush();
 
-        final Answer expected = answerRepository.findById(answer.getId()).get();
-        assertThat(expected.isDeleted()).isTrue();
+        final Optional<Answer> actual = answerRepository.findById(answer.getId());
+        assertThat(actual.isPresent()).isFalse();
     }
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class AnswerRepositoryTest {
-    public static final Answer A1 = new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserRepositoryTest.SANJIGI, QuestionRepositoryTest.Q1, "Answers Contents2");
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -3,14 +3,12 @@ package qna.domain;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableJpaAuditing
 @DataJpaTest
 public class AnswerRepositoryTest {
     public static final Answer A1 = new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "Answers Contents1");

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -73,7 +73,7 @@ public class AnswerRepositoryTest {
 
         final Answer answer = answerRepository.save(createTestAnswer(user, question));
 
-        answer.setContents("댓글 수정");
+        answer.updateContents("댓글 수정");
         assertThat(answer.getContents()).isEqualTo("댓글 수정");
     }
 

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -25,21 +25,26 @@ public class AnswerRepositoryTest {
 
     @Test
     void 댓글_등록() {
-        final Answer answer = answerRepository.save(A1);
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        final Answer answer = answerRepository.save(createTestAnswer(user, question));
         assertThat(answer).isNotNull();
     }
 
     @Test
     void 댓글_조회() {
-        final Answer expected = answerRepository.save(A1);
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        final Answer expected = answerRepository.save(createTestAnswer(user, question));
         final Answer actual = answerRepository.findById(expected.getId()).get();
         assertThat(actual).isNotNull();
     }
 
     @Test
     void 질문으로_댓글_조회() {
-        final Question question = questionRepository.save(new Question("제목", "내용"));
-        answerRepository.save(new Answer(UserRepositoryTest.JAVAJIGI, question, "답변 내용"));
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        answerRepository.save(createTestAnswer(user, question));
 
         List<Answer> answers = answerRepository.findByQuestionId(question.getId());
         assertThat(answers).hasSize(1);
@@ -47,8 +52,9 @@ public class AnswerRepositoryTest {
 
     @Test
     void 사용자로_댓글_조회() {
-        final User user = userRepository.save(new User("donghee.han", "password", "donghee", "donghee@slipp.net"));
-        answerRepository.save(new Answer(user, QuestionRepositoryTest.Q1, "답변 내용"));
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        answerRepository.save(createTestAnswer(user, question));
 
         List<Answer> answers = answerRepository.findByWriterId(user.getId());
         assertThat(answers).hasSize(1);
@@ -56,17 +62,33 @@ public class AnswerRepositoryTest {
 
     @Test
     void 댓글_수정() {
-        final Answer answer = answerRepository.save(new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "댓글 작성"));
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        final Answer answer = answerRepository.save(createTestAnswer(user, question));
         answer.setContents("댓글 수정");
         assertThat(answer.getContents()).isEqualTo("댓글 수정");
     }
 
     @Test
     void 댓글_삭제() {
-        final Answer answer = answerRepository.save(new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "댓글 작성"));
+        final User user = createTestUser();
+        final Question question = createTestQuestion();
+        final Answer answer = answerRepository.save(createTestAnswer(user, question));
         answerRepository.delete(answer);
 
         final Optional<Answer> actual = answerRepository.findById(answer.getId());
         assertThat(actual.isPresent()).isFalse();
+    }
+
+    private Answer createTestAnswer(User user, Question question) {
+        return new Answer(user, question, "댓글");
+    }
+
+    private User createTestUser() {
+        return userRepository.save(new User(1L, "donghee.han", "password", "donghee", "donghee.han@slipp.net"));
+    }
+
+    private Question createTestQuestion() {
+        return questionRepository.save(new Question(2L, "제목", "내용"));
     }
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -28,30 +28,30 @@ public class AnswerRepositoryTest {
         final User user = createTestUser();
         final Question question = createTestQuestion();
 
-        final Answer answer = answerRepository.save(createTestAnswer(user, question));
+        final Answer saved = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
-        assertThat(answer).isNotNull();
+        assertThat(saved).isNotNull();
     }
 
     @Test
     void 댓글_조회() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
-
-        final Answer expected = answerRepository.save(createTestAnswer(user, question));
+        final Answer expected = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         final Answer actual = answerRepository.findById(expected.getId()).get();
+
         assertThat(actual).isNotNull();
     }
 
     @Test
     void 질문으로_댓글_조회() {
         final User user = createTestUser();
-
         final Question question = createTestQuestion();
-        answerRepository.save(createTestAnswer(user, question));
+        answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         List<Answer> answers = answerRepository.findByQuestionId(question.getId());
+
         assertThat(answers).hasSize(1);
     }
 
@@ -59,10 +59,10 @@ public class AnswerRepositoryTest {
     void 사용자로_댓글_조회() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
-
-        answerRepository.save(createTestAnswer(user, question));
+        answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         List<Answer> answers = answerRepository.findByWriterId(user.getId());
+
         assertThat(answers).hasSize(1);
     }
 
@@ -70,10 +70,10 @@ public class AnswerRepositoryTest {
     void 댓글_수정() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
-
-        final Answer answer = answerRepository.save(createTestAnswer(user, question));
+        final Answer answer = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         answer.updateContents("댓글 수정");
+
         assertThat(answer.getContents()).isEqualTo("댓글 수정");
     }
 
@@ -81,16 +81,12 @@ public class AnswerRepositoryTest {
     void 댓글_삭제() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
-        final Answer answer = answerRepository.save(createTestAnswer(user, question));
+        final Answer answer = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         answerRepository.delete(answer);
 
         final Optional<Answer> actual = answerRepository.findById(answer.getId());
         assertThat(actual.isPresent()).isFalse();
-    }
-
-    private Answer createTestAnswer(User user, Question question) {
-        return new Answer(user, question, "댓글");
     }
 
     private User createTestUser() {

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -27,7 +27,9 @@ public class AnswerRepositoryTest {
     void 댓글_등록() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
+
         final Answer answer = answerRepository.save(createTestAnswer(user, question));
+
         assertThat(answer).isNotNull();
     }
 
@@ -35,7 +37,9 @@ public class AnswerRepositoryTest {
     void 댓글_조회() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
+
         final Answer expected = answerRepository.save(createTestAnswer(user, question));
+
         final Answer actual = answerRepository.findById(expected.getId()).get();
         assertThat(actual).isNotNull();
     }
@@ -43,6 +47,7 @@ public class AnswerRepositoryTest {
     @Test
     void 질문으로_댓글_조회() {
         final User user = createTestUser();
+
         final Question question = createTestQuestion();
         answerRepository.save(createTestAnswer(user, question));
 
@@ -54,6 +59,7 @@ public class AnswerRepositoryTest {
     void 사용자로_댓글_조회() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
+
         answerRepository.save(createTestAnswer(user, question));
 
         List<Answer> answers = answerRepository.findByWriterId(user.getId());
@@ -64,7 +70,9 @@ public class AnswerRepositoryTest {
     void 댓글_수정() {
         final User user = createTestUser();
         final Question question = createTestQuestion();
+
         final Answer answer = answerRepository.save(createTestAnswer(user, question));
+
         answer.setContents("댓글 수정");
         assertThat(answer.getContents()).isEqualTo("댓글 수정");
     }
@@ -74,6 +82,7 @@ public class AnswerRepositoryTest {
         final User user = createTestUser();
         final Question question = createTestQuestion();
         final Answer answer = answerRepository.save(createTestAnswer(user, question));
+
         answerRepository.delete(answer);
 
         final Optional<Answer> actual = answerRepository.findById(answer.getId());

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class AnswerRepositoryTest {
+    public static final Answer A1 = new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "Answers Contents1");
+    public static final Answer A2 = new Answer(UserRepositoryTest.SANJIGI, QuestionRepositoryTest.Q1, "Answers Contents2");
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -60,7 +60,7 @@ class DeleteHistoryRepositoryTest {
     void 댓글_삭제_이력() {
         final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
-        final Answer answer = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
+        final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
 
         repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), LocalDateTime.now())).deleteBy(user);
 

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -35,6 +35,7 @@ class DeleteHistoryRepositoryTest {
     @Test
     void 삭제_이력_조회() {
         final DeleteHistory expected = repository.save(H1);
+
         final Optional<DeleteHistory> actual = repository.findById(expected.getId());
         assertThat(actual).isNotEmpty();
     }
@@ -43,6 +44,7 @@ class DeleteHistoryRepositoryTest {
     void 질문_삭제_이력() {
         final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
+
         repository.save(new DeleteHistory(ContentType.QUESTION, question.getId(), 1L, LocalDateTime.now()));
 
         Optional<DeleteHistory> actual = repository.findByContentId(question.getId());
@@ -54,6 +56,7 @@ class DeleteHistoryRepositoryTest {
         final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
         final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
+
         repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), 1L, LocalDateTime.now()));
 
         Optional<DeleteHistory> actual = repository.findByContentId(answer.getId());

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -27,7 +27,7 @@ class DeleteHistoryRepositoryTest {
     @Test
     void 삭제_이력_저장() {
         final User user = userRepository.save(createTestUser());
-        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, LocalDateTime.now()).deleteBy(user);
         final DeleteHistory expected = repository.save(deleteHistory);
 
         assertThat(expected).isNotNull();
@@ -36,7 +36,7 @@ class DeleteHistoryRepositoryTest {
     @Test
     void 삭제_이력_조회() {
         final User user = userRepository.save(createTestUser());
-        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, LocalDateTime.now()).deleteBy(user);
         final DeleteHistory expected = repository.save(deleteHistory);
 
         final Optional<DeleteHistory> actual = repository.findById(expected.getId());
@@ -48,7 +48,7 @@ class DeleteHistoryRepositoryTest {
     void 질문_삭제_이력() {
         final User user = userRepository.save(createTestUser());
         final Question question = new Question(1L, "질문", "내용");
-        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), user, LocalDateTime.now());
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), LocalDateTime.now()).deleteBy(user);
 
         repository.save(deleteHistory);
 
@@ -62,7 +62,7 @@ class DeleteHistoryRepositoryTest {
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
         final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
 
-        repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), user, LocalDateTime.now()));
+        repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), LocalDateTime.now())).deleteBy(user);
 
         Optional<DeleteHistory> actual = repository.findByContentId(answer.getId());
         assertThat(actual).isNotEmpty();

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -51,7 +51,9 @@ class DeleteHistoryRepositoryTest {
 
     @Test
     void 댓글_삭제_이력() {
-        final Answer answer = answerRepository.save(new Answer(UserRepositoryTest.JAVAJIGI, QuestionRepositoryTest.Q1, "댓글 내용"));
+        final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
+        final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
+        final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
         repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), 1L, LocalDateTime.now()));
 
         Optional<DeleteHistory> actual = repository.findByContentId(answer.getId());

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -23,6 +23,9 @@ class DeleteHistoryRepositoryTest {
     @Autowired
     private AnswerRepository answerRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @Test
     void 삭제_이력_저장() {
         final DeleteHistory expected = repository.save(H1);
@@ -38,7 +41,8 @@ class DeleteHistoryRepositoryTest {
 
     @Test
     void 질문_삭제_이력() {
-        final Question question = questionRepository.save(QuestionRepositoryTest.Q1);
+        final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
+        final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
         repository.save(new DeleteHistory(ContentType.QUESTION, question.getId(), 1L, LocalDateTime.now()));
 
         Optional<DeleteHistory> actual = repository.findByContentId(question.getId());

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -60,7 +60,7 @@ class DeleteHistoryRepositoryTest {
     void 댓글_삭제_이력() {
         final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
-        final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
+        final Answer answer = answerRepository.save(new Answer("댓글 내용").toQuestion(question).writeBy(user));
 
         repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), LocalDateTime.now())).deleteBy(user);
 

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class DeleteHistoryRepositoryTest {
-    public static final DeleteHistory H1 = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
-    public static final DeleteHistory H2 = new DeleteHistory(ContentType.QUESTION, 2L, 2L, LocalDateTime.now());
 
     @Autowired
     private DeleteHistoryRepository repository;
@@ -28,24 +26,31 @@ class DeleteHistoryRepositoryTest {
 
     @Test
     void 삭제_이력_저장() {
-        final DeleteHistory expected = repository.save(H1);
+        final User user = userRepository.save(createTestUser());
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
+        final DeleteHistory expected = repository.save(deleteHistory);
+
         assertThat(expected).isNotNull();
     }
 
     @Test
     void 삭제_이력_조회() {
-        final DeleteHistory expected = repository.save(H1);
+        final User user = userRepository.save(createTestUser());
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
+        final DeleteHistory expected = repository.save(deleteHistory);
 
         final Optional<DeleteHistory> actual = repository.findById(expected.getId());
+
         assertThat(actual).isNotEmpty();
     }
 
     @Test
     void 질문_삭제_이력() {
-        final User user = userRepository.save(new User("donghee", "password", "donghee", "donghee.han@slipp.net"));
-        final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
+        final User user = userRepository.save(createTestUser());
+        final Question question = new Question(1L, "질문", "내용");
+        final DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, question.getId(), user, LocalDateTime.now());
 
-        repository.save(new DeleteHistory(ContentType.QUESTION, question.getId(), 1L, LocalDateTime.now()));
+        repository.save(deleteHistory);
 
         Optional<DeleteHistory> actual = repository.findByContentId(question.getId());
         assertThat(actual).isNotEmpty();
@@ -57,9 +62,14 @@ class DeleteHistoryRepositoryTest {
         final Question question = questionRepository.save(new Question("제목", "내용")).writeBy(user);
         final Answer answer = answerRepository.save(new Answer(user, question, "댓글 내용"));
 
-        repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), 1L, LocalDateTime.now()));
+        repository.save(new DeleteHistory(ContentType.ANSWER, answer.getId(), user, LocalDateTime.now()));
 
         Optional<DeleteHistory> actual = repository.findByContentId(answer.getId());
         assertThat(actual).isNotEmpty();
     }
+
+    private User createTestUser() {
+        return new User("donghee.han", "password", "donghee", "donghee.han@slipp.net");
+    }
 }
+

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -22,7 +22,7 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_등록() {
-        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final User user = userRepository.save(createTestUser());
         final Question question = new Question("제목", "내용").writeBy(user);
 
         final Question saved = questionRepository.save(question);
@@ -32,7 +32,7 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_조회() {
-        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final User user = userRepository.save(createTestUser());
         final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
 
         final Question question2 = questionRepository.findById(question1.getId()).get();
@@ -45,7 +45,7 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_수정() {
-        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final User user = userRepository.save(createTestUser());
         final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
 
         question1.updateTitle("수정 제목");
@@ -56,12 +56,16 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_삭제() {
-        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final User user = userRepository.save(createTestUser());
         final Question question = questionRepository.save(new Question("제목", "내용").writeBy(user));
 
         questionRepository.delete(question);
 
         final Optional<Question> actual = questionRepository.findById(question.getId());
         assertThat(actual.isPresent()).isFalse();
+    }
+
+    private User createTestUser() {
+        return new User("donghee.han", "password", "donghee", "donghee.han@slipp.net");
     }
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -24,7 +24,9 @@ public class QuestionRepositoryTest {
     void 질문_등록() {
         final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
         final Question question = new Question("제목", "내용").writeBy(user);
+
         final Question saved = questionRepository.save(question);
+
         assertThat(saved.getId()).isNotNull();
     }
 
@@ -34,6 +36,7 @@ public class QuestionRepositoryTest {
         final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
 
         final Question question2 = questionRepository.findById(question1.getId()).get();
+
         assertThat(question2).isNotNull();
         assertThat(question2.getTitle()).isEqualTo("제목");
         assertThat(question2.getContents()).isEqualTo("내용");
@@ -44,6 +47,7 @@ public class QuestionRepositoryTest {
     void 질문_수정() {
         final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
         final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
+
         question1.updateTitle("수정 제목");
 
         final Question question2 = questionRepository.findByTitle("수정 제목").get(0);
@@ -54,6 +58,7 @@ public class QuestionRepositoryTest {
     void 질문_삭제() {
         final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
         final Question question = questionRepository.save(new Question("제목", "내용").writeBy(user));
+
         questionRepository.delete(question);
 
         final Optional<Question> actual = questionRepository.findById(question.getId());

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -21,40 +22,41 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_등록() {
-        Question question = new Question("제목", "내용").writeBy(UserRepositoryTest.JAVAJIGI);
-        Question saved = questionRepository.save(question);
+        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final Question question = new Question("제목", "내용").writeBy(user);
+        final Question saved = questionRepository.save(question);
         assertThat(saved.getId()).isNotNull();
     }
 
     @Test
     void 질문_조회() {
-        final User user1 = userRepository.save(new User("donghee.han", "password", "donghee", "donghee@slipp.net"));
-        final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user1));
+        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
 
-        Question question2 = questionRepository.findById(question1.getId()).get();
+        final Question question2 = questionRepository.findById(question1.getId()).get();
         assertThat(question2).isNotNull();
         assertThat(question2.getTitle()).isEqualTo("제목");
         assertThat(question2.getContents()).isEqualTo("내용");
-
-        User user2 = userRepository.findById(question2.getWriterId()).get();
-        assertThat(user2).isEqualTo(user1);
+        assertThat(question2.getWriter()).isEqualTo(user);
     }
 
     @Test
     void 질문_수정() {
-        Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(UserRepositoryTest.SANJIGI));
+        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(user));
         question1.updateTitle("수정 제목");
 
-        Question question2 = questionRepository.findByTitle("수정 제목").get(0);
+        final Question question2 = questionRepository.findByTitle("수정 제목").get(0);
         assertThat(question2).isNotNull();
     }
 
     @Test
     void 질문_삭제() {
-        final Question question = questionRepository.save(new Question("제목", "내용").writeBy(UserRepositoryTest.SANJIGI));
+        final User user = userRepository.save(UserRepositoryTest.JAVAJIGI);
+        final Question question = questionRepository.save(new Question("제목", "내용").writeBy(user));
         questionRepository.delete(question);
 
-        final Optional<User> actual = userRepository.findById(question.getId());
+        final Optional<Question> actual = questionRepository.findById(question.getId());
         assertThat(actual.isPresent()).isFalse();
     }
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -3,13 +3,11 @@ package qna.domain;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableJpaAuditing
 @DataJpaTest
 public class QuestionRepositoryTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserRepositoryTest.JAVAJIGI);

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,14 +51,10 @@ public class QuestionRepositoryTest {
 
     @Test
     void 질문_삭제() {
-        final Question question1 = questionRepository.save(new Question("제목", "내용").writeBy(UserRepositoryTest.SANJIGI));
-        final List<Question> list = questionRepository.findByDeletedFalse();
-        assertThat(list).hasSize(1);
+        final Question question = questionRepository.save(new Question("제목", "내용").writeBy(UserRepositoryTest.SANJIGI));
+        questionRepository.delete(question);
 
-        questionRepository.delete(question1);
-        questionRepository.flush();
-
-        final Question expected = questionRepository.findById(question1.getId()).get();
-        assertThat(expected.isDeleted()).isTrue();
+        final Optional<User> actual = userRepository.findById(question.getId());
+        assertThat(actual.isPresent()).isFalse();
     }
 }

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -62,30 +62,6 @@ public class UserRepositoryTest {
         assertThat(actual.isPresent()).isFalse();
     }
 
-    @Test
-    void 사용자_질문_리스트_조회() {
-        final User user = userRepository.save(createTestUser());
-        questionRepository.save(new Question("제목", "내용").writeBy(user));
-
-        final User actualUser = userRepository.findByUserId(user.getUserId()).get();
-
-        Question actualQuation = actualUser.getQuestions().get(0);
-        assertThat(actualQuation.getTitle()).isEqualTo("제목");
-        assertThat(actualQuation.getContents()).isEqualTo("내용");
-    }
-
-    @Test
-    void 사용자_삭제_리스트_조회() {
-        final User user = userRepository.save(createTestUser());
-        final Question question = questionRepository.save(new Question("제목", "내용").writeBy(user));
-        deleteHistoryRepository.save(new DeleteHistory(ContentType.QUESTION, question.getId(), LocalDateTime.now())).deleteBy(user);
-
-        final User actualUser = userRepository.findByUserId(user.getUserId()).get();
-
-        final DeleteHistory deleteHistory = actualUser.getDeleteHistories().get(0);
-        assertThat(deleteHistory.getContentId()).isEqualTo(question.getId());
-    }
-
     private User createTestUser() {
         return new User("donghee.han", "password", "donghee", "donghee.han@slipp.net");
     }

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -3,13 +3,11 @@ package qna.domain;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableJpaAuditing
 @DataJpaTest
 public class UserRepositoryTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,6 +16,9 @@ public class UserRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
 
     @Test
     void 사용자_생성() {
@@ -52,6 +56,16 @@ public class UserRepositoryTest {
 
         Optional<User> actual = userRepository.findByUserId(user.getUserId());
         assertThat(actual.isPresent()).isFalse();
+    }
+
+    @Test
+    void 사용자_질문_리스트_조회() {
+        final User user = userRepository.save(createTestUser());
+        questionRepository.save(new Question("제목", "내용").writeBy(user));
+
+        final User actual = userRepository.findById(user.getId()).get();
+
+        assertThat(actual.getQuestions()).hasSize(1);
     }
 
     private User createTestUser() {

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -25,7 +25,9 @@ public class UserRepositoryTest {
     @Test
     void 사용자_조회() {
         User save = userRepository.save(createTestUser());
+
         Optional<User> find = userRepository.findByUserId(save.getUserId());
+
         assertThat(find.get()).isNotNull();
     }
 
@@ -45,7 +47,9 @@ public class UserRepositoryTest {
     @Test
     void 사용자_삭제() {
         User user = userRepository.save(createTestUser());
+
         userRepository.delete(user);
+
         Optional<User> actual = userRepository.findByUserId(user.getUserId());
         assertThat(actual.isPresent()).isFalse();
     }

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -18,20 +18,20 @@ public class UserRepositoryTest {
 
     @Test
     void 사용자_생성() {
-        User saved = userRepository.save(JAVAJIGI);
+        User saved = userRepository.save(createTestUser());
         assertThat(saved).isNotNull();
     }
 
     @Test
     void 사용자_조회() {
-        userRepository.save(JAVAJIGI);
-        Optional<User> user = userRepository.findByUserId(JAVAJIGI.getUserId());
-        assertThat(user.get()).isNotNull();
+        User save = userRepository.save(createTestUser());
+        Optional<User> find = userRepository.findByUserId(save.getUserId());
+        assertThat(find.get()).isNotNull();
     }
 
     @Test
     void 사용자_수정() {
-        User user = userRepository.save(new User("donghee.han", "password", "donghee", "donghee@slipp.net"));
+        User user = userRepository.save(createTestUser());
 
         user.setName("han");
         user.setEmail("han@slipp.net");
@@ -44,9 +44,13 @@ public class UserRepositoryTest {
 
     @Test
     void 사용자_삭제() {
-        User user = userRepository.save(new User("donghee.han", "password", "donghee", "donghee@slipp.net"));
+        User user = userRepository.save(createTestUser());
         userRepository.delete(user);
         Optional<User> actual = userRepository.findByUserId(user.getUserId());
         assertThat(actual.isPresent()).isFalse();
+    }
+
+    private User createTestUser() {
+        return new User("donghee.han", "password", "donghee", "donghee.han@slipp.net");
     }
 }

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -63,9 +63,11 @@ public class UserRepositoryTest {
         final User user = userRepository.save(createTestUser());
         questionRepository.save(new Question("제목", "내용").writeBy(user));
 
-        final User actual = userRepository.findById(user.getId()).get();
+        final User actualUser = userRepository.findByUserId(user.getUserId()).get();
 
-        assertThat(actual.getQuestions()).hasSize(1);
+        Question actualQuation = actualUser.getQuestions().get(0);
+        assertThat(actualQuation.getTitle()).isEqualTo("제목");
+        assertThat(actualQuation.getContents()).isEqualTo("내용");
     }
 
     private User createTestUser() {

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +20,9 @@ public class UserRepositoryTest {
 
     @Autowired
     private QuestionRepository questionRepository;
+
+    @Autowired
+    private DeleteHistoryRepository deleteHistoryRepository;
 
     @Test
     void 사용자_생성() {
@@ -68,6 +72,18 @@ public class UserRepositoryTest {
         Question actualQuation = actualUser.getQuestions().get(0);
         assertThat(actualQuation.getTitle()).isEqualTo("제목");
         assertThat(actualQuation.getContents()).isEqualTo("내용");
+    }
+
+    @Test
+    void 사용자_삭제_리스트_조회() {
+        final User user = userRepository.save(createTestUser());
+        final Question question = questionRepository.save(new Question("제목", "내용").writeBy(user));
+        deleteHistoryRepository.save(new DeleteHistory(ContentType.QUESTION, question.getId(), LocalDateTime.now())).deleteBy(user);
+
+        final User actualUser = userRepository.findByUserId(user.getUserId()).get();
+
+        final DeleteHistory deleteHistory = actualUser.getDeleteHistories().get(0);
+        assertThat(deleteHistory.getContentId()).isEqualTo(question.getId());
     }
 
     private User createTestUser() {

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,7 +89,7 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
                 new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -90,7 +90,7 @@ class QnaServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -39,7 +39,7 @@ class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserRepositoryTest.JAVAJIGI);
-        answer = new Answer(1L, UserRepositoryTest.JAVAJIGI, question, "Answers Contents1");
+        answer = new Answer(1L, "Answers Contents1").toQuestion(question).writeBy(UserRepositoryTest.JAVAJIGI);
         question.addAnswer(answer);
     }
 
@@ -77,7 +77,7 @@ class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, UserRepositoryTest.SANJIGI, QuestionRepositoryTest.Q1, "Answers Contents1");
+        Answer answer2 = new Answer(2L, "Answers Contents1").toQuestion(QuestionRepositoryTest.Q1).writeBy(UserRepositoryTest.SANJIGI);
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -39,7 +39,7 @@ class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserRepositoryTest.JAVAJIGI);
-        answer = new Answer(1L, "Answers Contents1").toQuestion(question).writeBy(UserRepositoryTest.JAVAJIGI);
+        answer = new Answer(1L, UserRepositoryTest.JAVAJIGI, question,"Answers Contents1");
         question.addAnswer(answer);
     }
 
@@ -77,7 +77,7 @@ class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, "Answers Contents1").toQuestion(QuestionRepositoryTest.Q1).writeBy(UserRepositoryTest.SANJIGI);
+        Answer answer2 = new Answer(2L, UserRepositoryTest.SANJIGI, QuestionRepositoryTest.Q1,"Answers Contents1");
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), LocalDateTime.now()).deleteBy(question.getWriter()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), LocalDateTime.now()).deleteBy(answer.getWriter())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
리뷰어님 안녕하세요. 😀
가장 먼저 지난 1단계 [리뷰](https://github.com/next-step/jwp-qna/pull/425) 감사드립니다!

2단계에서는 아래와 같은 내용이 추가 & 수정되었습니다.
1. `@ManyToOne` 또는 `@OneToMany`를 이용하여 엔티티 간 연관 관계 매핑
2. `@ManyToOne` 에 해당하는 엔티티를 의존 관계 주인으로 설정 (외래키 보유)
3. **연관 관계 편의 메서드** 사용으로 변경하여 엔티티 CRUD 과정에서  **외래키 참조 무결성 제약 조건** 오류 방지

2단계에서 요구하는 사항들을 제대로 충족했는지 모르겠네요...
구현이 부족한 부분이나 개선이 추가적으로 필요한 부분들을 지적해주시면 감사하겠습니다!

시간 여유 되실 때 리뷰 부탁드립니다! 🙏
감사합니다