### PR TITLE
Step2: 연관 관계 매핑

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -11,6 +11,11 @@
    1. Id 컬럼, Id 생성전략 필수
    2. 기본생성자 필요
    3. @Table, @Column 등 애노테이션 활용
+3. 다대일 연관관계 매핑
+   1. Answer -> Question
+   2. Answer -> User
+   3. DeleteHistory -> User
+   4. Question -> User
 
 ###2. 리포지토리 클래스
 1. 리포지토리 목록

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -13,11 +13,13 @@ public class Answer extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private User writer;
 
-    @Column(name = "question_id")
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    Question question;
 
     @Lob
     @Column(name = "contents")
@@ -44,25 +46,25 @@ public class Answer extends BaseTimeEntity{
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
         return id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public String getContents() {
@@ -81,8 +83,8 @@ public class Answer extends BaseTimeEntity{
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
+                ", writer=" + writer +
+                ", question=" + question +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -18,8 +18,9 @@ public class DeleteHistory {
     @Column(name = "content_id")
     private Long contentId;
 
-    @Column(name = "deleted_by_id")
-    private Long deletedById;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deleted_by_id")
+    private User deletedBy;
 
     @Column(name = "create_date")
     private LocalDateTime createDate = LocalDateTime.now();
@@ -27,10 +28,10 @@ public class DeleteHistory {
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -46,12 +47,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&
                 Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+                Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedBy);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deletedBy=" + deletedBy +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -16,8 +16,9 @@ public class Question extends BaseTimeEntity{
     @Column(name = "contents")
     private String contents;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private User writer;
 
     @Column(name = "deleted", nullable = false)
     private boolean deleted = false;
@@ -36,12 +37,12 @@ public class Question extends BaseTimeEntity{
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -60,8 +61,8 @@ public class Question extends BaseTimeEntity{
         return contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public boolean isDeleted() {
@@ -78,7 +79,7 @@ public class Question extends BaseTimeEntity{
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -26,7 +26,7 @@ public class User extends BaseTimeEntity{
     @Column(name="email", length = 50)
     private String email;
 
-    private User() {
+    protected User() {
     }
 
     public User(String userId, String password, String name, String email) {

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -51,7 +51,7 @@ public class QnaService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,7 +48,7 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -13,9 +13,12 @@ import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 class AnswerRepositoryTest {
-    @Autowired AnswerRepository answerRepository;
-    @Autowired QuestionRepository questionRepository;
-    @Autowired UserRepository userRepository;
+    @Autowired
+    AnswerRepository answerRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+    @Autowired
+    UserRepository userRepository;
 
     private Question question;
     private User user;

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,13 +8,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 class AnswerRepositoryTest {
     @Autowired AnswerRepository answerRepository;
+
+    @BeforeEach
+    void initialize(){
+        AnswerTest.A1.setDeleted(true);
+    }
 
     @Test
     @DisplayName("Answer 저장")
@@ -25,7 +30,6 @@ class AnswerRepositoryTest {
     @Test
     @DisplayName("Answer를 QuestionId, DeletedFalse로 조회")
     void Answer_조회_byQuestionId_DeletedFalse(){
-        AnswerTest.A1.setDeleted(true);
         answerRepository.save(AnswerTest.A1);
         Answer answerDeletedFalse = answerRepository.save(AnswerTest.A2);
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(QuestionTest.Q1.getId());
@@ -35,8 +39,13 @@ class AnswerRepositoryTest {
     @Test
     @DisplayName("Answer를 Id, DeletedFalse로 조회")
     void Answer_조회_byId_DeletedFalse(){
-        Answer saved = answerRepository.save(AnswerTest.A1);
-        Optional<Answer> answer = answerRepository.findByIdAndDeletedFalse(saved.getId());
-        assertThat(answer.get()).isEqualTo(saved);
+        Answer answerDeletedTrue = answerRepository.save(AnswerTest.A1);
+        Answer answerDeletedFalse = answerRepository.save(AnswerTest.A2);
+        Assertions.assertAll(
+                () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedTrue.getId()))
+                        .isEmpty(),
+                () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedFalse.getId())).get()
+                        .isEqualTo(AnswerTest.A2)
+        );
     }
 }

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -23,7 +23,7 @@ class AnswerRepositoryTest {
     @BeforeEach
     void initialize(){
         user = userRepository.save(UserTest.JAVAJIGI);
-        question = questionRepository.save(QuestionTest.Q1);
+        question = questionRepository.save(new Question("title1", "contents1").writeBy(user));
     }
 
     @Test

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class AnswerRepositoryTest {
@@ -37,8 +37,8 @@ class AnswerRepositoryTest {
     }
 
     @Test
-    @DisplayName("Answer를 QuestionId, DeletedFalse로 조회")
-    void Answer_조회_byQuestionId_DeletedFalse(){
+    @DisplayName("Answer 조회: by QuestionId, DeletedFalse")
+    void Answer_조회_by_QuestionId_DeletedFalse(){
         generateAnswerDeletedTrue();
         Answer answerDeletedFalse = answerRepository.save(new Answer(user, question, "Answers Contents1"));
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(question.getId());
@@ -46,11 +46,11 @@ class AnswerRepositoryTest {
     }
 
     @Test
-    @DisplayName("Answer를 Id, DeletedFalse로 조회")
-    void Answer_조회_byId_DeletedFalse(){
+    @DisplayName("Answer 조회: by Id, DeletedFalse")
+    void Answer_조회_by_Id_DeletedFalse(){
         Answer answerDeletedTrue = generateAnswerDeletedTrue();
         Answer answerDeletedFalse = answerRepository.save(new Answer(user, question, "Answers Contents1"));
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedTrue.getId()))
                         .isEmpty(),
                 () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedFalse.getId())).get()

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -14,38 +14,50 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 class AnswerRepositoryTest {
     @Autowired AnswerRepository answerRepository;
+    @Autowired QuestionRepository questionRepository;
+    @Autowired UserRepository userRepository;
+
+    private Question question;
+    private User user;
 
     @BeforeEach
     void initialize(){
-        AnswerTest.A1.setDeleted(true);
+        user = userRepository.save(UserTest.JAVAJIGI);
+        question = questionRepository.save(QuestionTest.Q1);
     }
 
     @Test
     @DisplayName("Answer 저장")
     void save(){
-        Answer saved = answerRepository.save(AnswerTest.A1);
+        Answer saved = answerRepository.save(new Answer(user, question, "Answers Contents1"));
         assertThat(saved.getId()).isNotNull();
     }
 
     @Test
     @DisplayName("Answer를 QuestionId, DeletedFalse로 조회")
     void Answer_조회_byQuestionId_DeletedFalse(){
-        answerRepository.save(AnswerTest.A1);
-        Answer answerDeletedFalse = answerRepository.save(AnswerTest.A2);
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(QuestionTest.Q1.getId());
+        generateAnswerDeletedTrue();
+        Answer answerDeletedFalse = answerRepository.save(new Answer(user, question, "Answers Contents1"));
+        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(question.getId());
         assertThat(answers).containsExactly(answerDeletedFalse);
     }
 
     @Test
     @DisplayName("Answer를 Id, DeletedFalse로 조회")
     void Answer_조회_byId_DeletedFalse(){
-        Answer answerDeletedTrue = answerRepository.save(AnswerTest.A1);
-        Answer answerDeletedFalse = answerRepository.save(AnswerTest.A2);
+        Answer answerDeletedTrue = generateAnswerDeletedTrue();
+        Answer answerDeletedFalse = answerRepository.save(new Answer(user, question, "Answers Contents1"));
         Assertions.assertAll(
                 () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedTrue.getId()))
                         .isEmpty(),
                 () -> assertThat(answerRepository.findByIdAndDeletedFalse(answerDeletedFalse.getId())).get()
-                        .isEqualTo(AnswerTest.A2)
+                        .isEqualTo(answerDeletedFalse)
         );
+    }
+
+    private Answer generateAnswerDeletedTrue() {
+        Answer answer = new Answer(user, question, "Answers Contents1");
+        answer.setDeleted(true);
+        return answerRepository.save(answer);
     }
 }

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,12 +9,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class DeleteHistoryRepositoryTest {
-    @Autowired DeleteHistoryRepository deleteHistoryRepository;
-    @Autowired UserRepository userRepository;
+    @Autowired
+    DeleteHistoryRepository deleteHistoryRepository;
+    @Autowired
+    UserRepository userRepository;
 
     private User user;
 

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,13 +14,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class DeleteHistoryRepositoryTest {
-    @Autowired
-    DeleteHistoryRepository deleteHistoryRepository;
+    @Autowired DeleteHistoryRepository deleteHistoryRepository;
+    @Autowired UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void initialize(){
+        user = userRepository.save(UserTest.JAVAJIGI);
+    }
 
     @Test
     @DisplayName("DeleteHistory 저장")
     void save(){
-        DeleteHistory history = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+        DeleteHistory history = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
         DeleteHistory saved = deleteHistoryRepository.save(history);
         assertThat(saved.getId()).isNotNull();
     }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,7 +1,6 @@
 package qna.domain;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,23 +15,11 @@ class QuestionRepositoryTest {
     @Autowired
     QuestionRepository questionRepository;
 
-    @BeforeEach
-    void initialize(){
-        QuestionTest.Q1.setDeleted(true);
-    }
-
-    @Test
-    @DisplayName("Question 저장")
-    void save(){
-        Question saved = questionRepository.save(QuestionTest.Q1);
-        assertThat(saved.getId()).isNotNull();
-    }
-
     @Test
     @DisplayName("Question을 DeletedFalse로 조회")
     void Question_조회_byDeletedFalse(){
-        questionRepository.save(QuestionTest.Q1);
-        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q2);
+        generateQuestionDeletedTrue();
+        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q1);
         List<Question> questions = questionRepository.findByDeletedFalse();
         assertThat(questions).containsExactly(questionDeletedFalse);
     }
@@ -40,13 +27,19 @@ class QuestionRepositoryTest {
     @Test
     @DisplayName("Question을 Id, DeletedFalse로 조회")
     void Question_조회_byId_DeletedFalse(){
-        Question questionDeletedTrue = questionRepository.save(QuestionTest.Q1);
-        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q2);
+        Question questionDeletedTrue = generateQuestionDeletedTrue();
+        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q1);
         Assertions.assertAll(
                 () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedTrue.getId()))
                         .isEmpty(),
                 () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedFalse.getId())).get()
-                        .isEqualTo(QuestionTest.Q2)
+                        .isEqualTo(questionDeletedFalse)
         );
+    }
+
+    private Question generateQuestionDeletedTrue() {
+        Question question = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        question.setDeleted(true);
+        return questionRepository.save(question);
     }
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,14 +13,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class QuestionRepositoryTest {
-    @Autowired
-    QuestionRepository questionRepository;
+    @Autowired QuestionRepository questionRepository;
+    @Autowired UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void initialize() {
+        user = userRepository.save(UserTest.JAVAJIGI);
+    }
 
     @Test
     @DisplayName("Question을 DeletedFalse로 조회")
     void Question_조회_byDeletedFalse(){
         generateQuestionDeletedTrue();
-        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q1);
+        Question questionDeletedFalse = questionRepository
+                .save(new Question("title1", "contents1").writeBy(user));
         List<Question> questions = questionRepository.findByDeletedFalse();
         assertThat(questions).containsExactly(questionDeletedFalse);
     }
@@ -28,7 +37,8 @@ class QuestionRepositoryTest {
     @DisplayName("Question을 Id, DeletedFalse로 조회")
     void Question_조회_byId_DeletedFalse(){
         Question questionDeletedTrue = generateQuestionDeletedTrue();
-        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q1);
+        Question questionDeletedFalse = questionRepository
+                .save(new Question("title1", "contents1").writeBy(user));
         Assertions.assertAll(
                 () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedTrue.getId()))
                         .isEmpty(),
@@ -38,7 +48,7 @@ class QuestionRepositoryTest {
     }
 
     private Question generateQuestionDeletedTrue() {
-        Question question = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
+        Question question = new Question("title1", "contents1").writeBy(user);
         question.setDeleted(true);
         return questionRepository.save(question);
     }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -13,8 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class QuestionRepositoryTest {
-    @Autowired QuestionRepository questionRepository;
-    @Autowired UserRepository userRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+    @Autowired
+    UserRepository userRepository;
 
     private User user;
 

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,12 +1,13 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +15,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class QuestionRepositoryTest {
     @Autowired
     QuestionRepository questionRepository;
+
+    @BeforeEach
+    void initialize(){
+        QuestionTest.Q1.setDeleted(true);
+    }
 
     @Test
     @DisplayName("Question 저장")
@@ -25,7 +31,6 @@ class QuestionRepositoryTest {
     @Test
     @DisplayName("Question을 DeletedFalse로 조회")
     void Question_조회_byDeletedFalse(){
-        QuestionTest.Q1.setDeleted(true);
         questionRepository.save(QuestionTest.Q1);
         Question questionDeletedFalse = questionRepository.save(QuestionTest.Q2);
         List<Question> questions = questionRepository.findByDeletedFalse();
@@ -35,8 +40,13 @@ class QuestionRepositoryTest {
     @Test
     @DisplayName("Question을 Id, DeletedFalse로 조회")
     void Question_조회_byId_DeletedFalse(){
-        Question saved = questionRepository.save(QuestionTest.Q1);
-        Optional<Question> question = questionRepository.findByIdAndDeletedFalse(saved.getId());
-        assertThat(question.get()).isEqualTo(saved);
+        Question questionDeletedTrue = questionRepository.save(QuestionTest.Q1);
+        Question questionDeletedFalse = questionRepository.save(QuestionTest.Q2);
+        Assertions.assertAll(
+                () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedTrue.getId()))
+                        .isEmpty(),
+                () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedFalse.getId())).get()
+                        .isEqualTo(QuestionTest.Q2)
+        );
     }
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,6 +1,5 @@
 package qna.domain;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class QuestionRepositoryTest {
@@ -26,8 +26,15 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    @DisplayName("Question을 DeletedFalse로 조회")
-    void Question_조회_byDeletedFalse(){
+    @DisplayName("Question 저장")
+    void save(){
+        Question saved = questionRepository.save(new Question("title1", "contents1").writeBy(user));
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Question 조회: by DeletedFalse")
+    void Question_조회_by_DeletedFalse(){
         generateQuestionDeletedTrue();
         Question questionDeletedFalse = questionRepository
                 .save(new Question("title1", "contents1").writeBy(user));
@@ -36,12 +43,12 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    @DisplayName("Question을 Id, DeletedFalse로 조회")
+    @DisplayName("Question 조회: by Id, DeletedFalse")
     void Question_조회_byId_DeletedFalse(){
         Question questionDeletedTrue = generateQuestionDeletedTrue();
         Question questionDeletedFalse = questionRepository
                 .save(new Question("title1", "contents1").writeBy(user));
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedTrue.getId()))
                         .isEmpty(),
                 () -> assertThat(questionRepository.findByIdAndDeletedFalse(questionDeletedFalse.getId())).get()

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -22,7 +22,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    @DisplayName("User을 UserId로 조회")
+    @DisplayName("User 조회: by UserId")
     void User_byUserId(){
         User saved = userRepository.save(UserTest.JAVAJIGI);
         Optional<User> user = userRepository.findByUserId(UserTest.JAVAJIGI.getUserId());

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -2,7 +2,6 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,8 +89,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -89,7 +89,7 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
                 new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -90,7 +90,7 @@ class QnaServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
선흠 리뷰어님, 안녕하세요^^
JPA 미션 Step 2 연관 관계 매핑 PR요청 드립니다.

미션에서 요구된 DDL에 맞게 엔티티에 ManyToOne 연관관계를 추가하였으며, 
관련 코드에서 엔티티의 Id만을 가지고 처리하던 부분도 모두 엔티티 자체를 가지고 처리하도록 수정하였습니다.
 
그런데 Step1(#444)에서 주신 피드백 중, `테스트 중 Fixture는 상수보다는 함수로 제공`하라는 조언을 주셔서, 테스트에 private 메소드를 추가해서 구현해보았는데, 제가 해당 부분을 맞게 이해하고 반영한 것인지 궁금합니다. 😅 

그럼 시간 나실 때 확인 부탁 드리며, 이번 주도 즐거운 한 주 보내세요!
감사합니다^^!