### PR TITLE
Step2 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
   - [x] QuestionRepositoryTest
   - [x] UserRepositoryTest
   - [x] DeleteHistoryRepositoryTest
+- 연관 관계 매핑
+  - [ ] Question - Answer 연관 관계 매핑
+  - [ ] User - Answer 연관 관계 매핑
+  - [ ] User - Question 연관 관계 매핑
+  - [ ] User - DeleteHistory 연관 관계 매핑
 
 ### DDL
 ```SQL

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@
   - [x] UserRepositoryTest
   - [x] DeleteHistoryRepositoryTest
 - 연관 관계 매핑
-  - [ ] Question - Answer 연관 관계 매핑
-  - [ ] User - Answer 연관 관계 매핑
-  - [ ] User - Question 연관 관계 매핑
-  - [ ] User - DeleteHistory 연관 관계 매핑
+  - [x] Question - Answer 연관 관계 매핑
+  - [x] User - Answer 연관 관계 매핑
+  - [x] User - Question 연관 관계 매핑
+  - [x] User - DeleteHistory 연관 관계 매핑
+- 테스트 데이터 generator 생성
+  - static 객체 활용 시 테스트 데이터가 공유되는 문제가 발생
 
 ### DDL
 ```SQL

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -101,10 +101,12 @@ public class Answer extends BaseEntity {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
 
 		Answer answer = (Answer)o;
 

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -4,10 +4,14 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
@@ -18,100 +22,104 @@ import qna.domain.user.User;
 @Entity
 public class Answer extends BaseEntity {
 
-    protected Answer() {
-    }
+	protected Answer() {
+	}
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(updatable = false)
+	private Long id;
 
-    private Long writerId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "wirter_Id", foreignKey = @ForeignKey(name = "fk_answer_writer"), nullable = false)
+	private User writer;
 
-    private Long questionId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"), nullable = false)
+	private Question question;
 
-    @Lob
-    private String contents;
+	@Lob
+	private String contents;
 
-    @Column(nullable = false)
-    private boolean deleted = false;
+	@Column(nullable = false)
+	private boolean deleted = false;
 
-    public Answer(User writer, Question question, String contents) {
-        this(null, writer, question, contents);
-    }
+	public Answer(User writer, Question question, String contents) {
+		this(null, writer, question, contents);
+	}
 
-    public Answer(Long id, User writer, Question question, String contents) {
-        this.id = id;
+	public Answer(Long id, User writer, Question question, String contents) {
+		this.id = id;
 
-        if (Objects.isNull(writer)) {
-            throw new UnAuthorizedException();
-        }
+		if (Objects.isNull(writer)) {
+			throw new UnAuthorizedException();
+		}
 
-        if (Objects.isNull(question)) {
-            throw new NotFoundException();
-        }
+		if (Objects.isNull(question)) {
+			throw new NotFoundException();
+		}
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
-        this.contents = contents;
-    }
+		this.writer = writer;
+		this.question = question;
+		this.contents = contents;
+	}
 
-    public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
-    }
+	public boolean isOwner(User writer) {
+		return this.writer.equals(writer);
+	}
 
-    public void toQuestion(Question question) {
-        this.questionId = question.getId();
-    }
+	public void toQuestion(Question question) {
+		this.question = question;
+	}
 
-    public Long getId() {
-        return id;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+	public void setId(Long id) {
+		this.id = id;
+	}
 
-    public Long getWriterId() {
-        return writerId;
-    }
+	public User getWriter() {
+		return writer;
+	}
 
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
+	public void setWriter(User writer) {
+		this.writer = writer;
+	}
 
-    public Long getQuestionId() {
-        return questionId;
-    }
+	public Question getQuestion() {
+		return question;
+	}
 
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
-    }
+	public void setQuestion(Question question) {
+		this.question = question;
+	}
 
-    public String getContents() {
-        return contents;
-    }
+	public String getContents() {
+		return contents;
+	}
 
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
+	public void setContents(String contents) {
+		this.contents = contents;
+	}
 
-    public boolean isDeleted() {
-        return deleted;
-    }
+	public boolean isDeleted() {
+		return deleted;
+	}
 
-    public void setDeleted(boolean deleted) {
-        this.deleted = deleted;
-    }
+	public void setDeleted(boolean deleted) {
+		this.deleted = deleted;
+	}
 
-    @Override
-    public String toString() {
-        return "Answer{" +
-                "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
-                ", contents='" + contents + '\'' +
-                ", deleted=" + deleted +
-                '}';
-    }
+	@Override
+	public String toString() {
+		return "Answer{" +
+			"id=" + id +
+			", writerId=" + writer +
+			", questionId=" + question +
+			", contents='" + contents + '\'' +
+			", deleted=" + deleted +
+			'}';
+	}
 }

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -101,6 +101,23 @@ public class Answer extends BaseEntity {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		Answer answer = (Answer)o;
+
+		return Objects.equals(id, answer.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return id != null ? id.hashCode() : 0;
+	}
+
+	@Override
 	public String toString() {
 		return "Answer{" +
 			"id=" + id +

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -76,16 +76,8 @@ public class Answer extends BaseEntity {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public User getWriter() {
 		return writer;
-	}
-
-	public void setWriter(User writer) {
-		this.writer = writer;
 	}
 
 	public Question getQuestion() {
@@ -98,10 +90,6 @@ public class Answer extends BaseEntity {
 
 	public String getContents() {
 		return contents;
-	}
-
-	public void setContents(String contents) {
-		this.contents = contents;
 	}
 
 	public boolean isDeleted() {

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -27,7 +27,6 @@ public class Answer extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(updatable = false)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/qna/domain/answer/Answer.java
+++ b/src/main/java/qna/domain/answer/Answer.java
@@ -83,10 +83,6 @@ public class Answer extends BaseEntity {
 		return question;
 	}
 
-	public void setQuestion(Question question) {
-		this.question = question;
-	}
-
 	public String getContents() {
 		return contents;
 	}

--- a/src/main/java/qna/domain/answer/AnswerRepository.java
+++ b/src/main/java/qna/domain/answer/AnswerRepository.java
@@ -5,8 +5,10 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import qna.domain.question.Question;
+
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
+    List<Answer> findByQuestionAndDeletedFalse(Question question);
 
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/qna/domain/common/BaseEntity.java
+++ b/src/main/java/qna/domain/common/BaseEntity.java
@@ -2,7 +2,6 @@ package qna.domain.common;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 
@@ -14,7 +13,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-	@Column(nullable = false, updatable = false)
 	@CreatedDate
 	private LocalDateTime createdAt;
 

--- a/src/main/java/qna/domain/common/BaseEntity.java
+++ b/src/main/java/qna/domain/common/BaseEntity.java
@@ -20,12 +20,4 @@ public abstract class BaseEntity {
 
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
-
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
 }

--- a/src/main/java/qna/domain/deletehistory/DeleteHistory.java
+++ b/src/main/java/qna/domain/deletehistory/DeleteHistory.java
@@ -3,7 +3,6 @@ package qna.domain.deletehistory;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -27,7 +26,6 @@ public class DeleteHistory extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(updatable = false)
 	private Long id;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/qna/domain/deletehistory/DeleteHistory.java
+++ b/src/main/java/qna/domain/deletehistory/DeleteHistory.java
@@ -48,20 +48,21 @@ public class DeleteHistory extends BaseEntity {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
+
 		DeleteHistory that = (DeleteHistory)o;
-		return Objects.equals(id, that.id) &&
-			contentType == that.contentType &&
-			Objects.equals(contentId, that.contentId) &&
-			Objects.equals(deletedBy, that.deletedBy);
+
+		return Objects.equals(id, that.id);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, contentType, contentId, deletedBy);
+		return id != null ? id.hashCode() : 0;
 	}
 
 	@Override

--- a/src/main/java/qna/domain/deletehistory/DeleteHistory.java
+++ b/src/main/java/qna/domain/deletehistory/DeleteHistory.java
@@ -7,64 +7,73 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import qna.domain.ContentType;
 import qna.domain.common.BaseEntity;
+import qna.domain.user.User;
 
 @Entity
 public class DeleteHistory extends BaseEntity {
 
-    protected DeleteHistory() {
-    }
+	protected DeleteHistory() {
+	}
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(updatable = false)
+	private Long id;
 
-    @Enumerated(EnumType.STRING)
-    private ContentType contentType;
+	@Enumerated(EnumType.STRING)
+	private ContentType contentType;
 
-    private Long contentId;
+	private Long contentId;
 
-    private Long deletedById;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"), nullable = false)
+	private User deletedBy;
 
-    private LocalDateTime createDate = LocalDateTime.now();
+	private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
-        this.contentType = contentType;
-        this.contentId = contentId;
-        this.deletedById = deletedById;
-        this.createDate = createDate;
-    }
+	public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
+		this.contentType = contentType;
+		this.contentId = contentId;
+		this.deletedBy = deletedBy;
+		this.createDate = createDate;
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DeleteHistory that = (DeleteHistory) o;
-        return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
-    }
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		DeleteHistory that = (DeleteHistory)o;
+		return Objects.equals(id, that.id) &&
+			contentType == that.contentType &&
+			Objects.equals(contentId, that.contentId) &&
+			Objects.equals(deletedBy, that.deletedBy);
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, contentType, contentId, deletedBy);
+	}
 
-    @Override
-    public String toString() {
-        return "DeleteHistory{" +
-                "id=" + id +
-                ", contentType=" + contentType +
-                ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
-                ", createDate=" + createDate +
-                '}';
-    }
+	@Override
+	public String toString() {
+		return "DeleteHistory{" +
+			"id=" + id +
+			", contentType=" + contentType +
+			", contentId=" + contentId +
+			", deletedById=" + deletedBy +
+			", createDate=" + createDate +
+			'}';
+	}
 }

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -2,10 +2,14 @@ package qna.domain.question;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 
 import qna.domain.answer.Answer;
 import qna.domain.common.BaseEntity;
@@ -13,9 +17,6 @@ import qna.domain.user.User;
 
 @Entity
 public class Question extends BaseEntity {
-
-    protected Question() {
-    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,10 +29,15 @@ public class Question extends BaseEntity {
     @Lob
     private String contents;
 
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"), nullable = false)
+    private User writer;
 
     @Column(nullable = false)
     private boolean deleted = false;
+
+    protected Question() {
+    }
 
     public Question(String title, String contents) {
         this(null, title, contents);
@@ -44,12 +50,12 @@ public class Question extends BaseEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -68,8 +74,8 @@ public class Question extends BaseEntity {
         return contents;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public boolean isDeleted() {
@@ -86,7 +92,7 @@ public class Question extends BaseEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writerId=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -102,10 +102,12 @@ public class Question extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
 
         Question question = (Question)o;
 

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -1,5 +1,7 @@
 package qna.domain.question;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -84,6 +86,23 @@ public class Question extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Question question = (Question)o;
+
+        return Objects.equals(id, question.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -25,7 +25,6 @@ public class Question extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false, insertable = false)
     private Long id;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -1,5 +1,7 @@
 package qna.domain.question;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -12,6 +14,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import qna.domain.answer.Answer;
 import qna.domain.common.BaseEntity;
@@ -38,6 +41,9 @@ public class Question extends BaseEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers = new ArrayList<>();
+
     protected Question() {
     }
 
@@ -62,6 +68,13 @@ public class Question extends BaseEntity {
 
     public void addAnswer(Answer answer) {
         answer.toQuestion(this);
+        if (!this.answers.contains(answer)) {
+            this.answers.add(answer);
+        }
+    }
+
+    public List<Answer> getAnswers() {
+        return this.answers;
     }
 
     public Long getId() {

--- a/src/main/java/qna/domain/question/Question.java
+++ b/src/main/java/qna/domain/question/Question.java
@@ -60,32 +60,16 @@ public class Question extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     public String getContents() {
         return contents;
     }
 
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
-
     public Long getWriterId() {
         return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/user/User.java
+++ b/src/main/java/qna/domain/user/User.java
@@ -102,10 +102,12 @@ public class User extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
 
         User user = (User)o;
 

--- a/src/main/java/qna/domain/user/User.java
+++ b/src/main/java/qna/domain/user/User.java
@@ -103,6 +103,23 @@ public class User extends BaseEntity {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        User user = (User)o;
+
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
     public String toString() {
         return "User{" +
                 "id=" + id +

--- a/src/main/java/qna/domain/user/User.java
+++ b/src/main/java/qna/domain/user/User.java
@@ -20,9 +20,7 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false)
     private Long id;
-
 
     @Column(nullable = false, length = 20, unique = true)
     private String userId;

--- a/src/main/java/qna/domain/user/User.java
+++ b/src/main/java/qna/domain/user/User.java
@@ -86,40 +86,20 @@ public class User extends BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getUserId() {
         return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
     }
 
     public String getPassword() {
         return password;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public String getEmail() {
         return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     @Override

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -55,10 +55,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -55,7 +55,7 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter().getId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -46,7 +46,7 @@ public class QnaService {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
+        List<Answer> answers = answerRepository.findByQuestionAndDeletedFalse(question);
         for (Answer answer : answers) {
             if (!answer.isOwner(loginUser)) {
                 throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
@@ -58,7 +58,7 @@ public class QnaService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
@@ -2,23 +2,50 @@ package qna.domain.answer;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static qna.domain.answer.AnswerTest.*;
 
-import java.util.Optional;
+import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.TestConstructor;
+
+import qna.domain.generator.QuestionGenerator;
+import qna.domain.generator.UserGenerator;
+import qna.domain.question.AnswerGenerator;
+import qna.domain.question.Question;
+import qna.domain.user.User;
 
 @DataJpaTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Import({AnswerGenerator.class, QuestionGenerator.class, UserGenerator.class})
 @DisplayName("Answer Repository 테스트")
 class AnswerRepositoryTest {
 
-	@Autowired
-	private AnswerRepository answerRepository;
+	private final AnswerRepository answerRepository;
+	private final AnswerGenerator answerGenerator;
+	private final QuestionGenerator questionGenerator;
+	private final UserGenerator userGenerator;
+	private final EntityManager entityManager;
 
+	public AnswerRepositoryTest(
+		AnswerRepository answerRepository,
+		AnswerGenerator answerGenerator,
+		QuestionGenerator questionGenerator,
+		UserGenerator userGenerator,
+		EntityManager entityManager
+	) {
+		this.answerRepository = answerRepository;
+		this.answerGenerator = answerGenerator;
+		this.questionGenerator = questionGenerator;
+		this.userGenerator = userGenerator;
+		this.entityManager = entityManager;
+	}
+
+	// TODO 삭제
 	@BeforeEach
 	void setUp() {
 		answerRepository.deleteAllInBatch();
@@ -27,72 +54,81 @@ class AnswerRepositoryTest {
 	@Test
 	@DisplayName("답변 저장 테스트")
 	void saveTest() {
-		Answer answer = answerRepository.save(A1);
+		User questionWriter = userGenerator.savedUser(UserGenerator.questionWriter());
+		Question question = questionGenerator.savedQuestion(questionWriter);
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer answer = new Answer(answerWriter, question, "answer contents");
+
+		Answer actual = answerRepository.save(answer);
 
 		assertAll(
-			() -> assertThat(answer).isNotNull(),
-			() -> assertThat(answer.getId()).isNotNull(),
-			() -> assertThat(answer.getId()).isEqualTo(A1.getId()),
-			() -> assertThat(answer.getContents()).isEqualTo(A1.getContents()),
-			() -> assertThat(answer.isDeleted()).isEqualTo(A1.isDeleted()),
-			() -> assertThat(answer.getQuestion()).isEqualTo(A1.getQuestion()),
-			() -> assertThat(answer.getWriter()).isEqualTo(A1.getWriter())
+			() -> assertThat(actual).isNotNull(),
+			() -> assertThat(actual.getId()).isNotNull(),
+			() -> assertThat(actual.isDeleted()).isFalse(),
+			() -> assertThat(actual.getQuestion()).isEqualTo(question),
+			() -> assertThat(actual).isSameAs(answer)
 		);
+	}
+
+	@Test
+	@DisplayName("답변 저장 시, 작성자가 영속 상태가 아니면 예외 반환")
+	void saveWithNotPersistedWriterTest() {
+		// given
+		Question question = questionGenerator.savedQuestion(userGenerator.savedUser(UserGenerator.questionWriter()));
+		User answerWriter = UserGenerator.answerWriter();
+		Answer given = AnswerGenerator.answer(answerWriter, question, "answer contents");
+
+		// when
+		assertThatThrownBy(() -> answerRepository.save(given))
+			.isInstanceOf(InvalidDataAccessApiUsageException.class);
+	}
+
+	@Test
+	@DisplayName("답변 저장 시, 질문이 영속 상태가 아니면 예외 반환")
+	void saveWithNotPersistedQuestionTest() {
+		// given
+		User questionWriter = UserGenerator.questionWriter();
+		Question question = QuestionGenerator.question(questionWriter);
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer given = AnswerGenerator.answer(answerWriter, question, "answer contents");
+
+		// when
+		assertThatThrownBy(() -> answerRepository.save(given))
+			.isInstanceOf(InvalidDataAccessApiUsageException.class);
 	}
 
 	@Test
 	@DisplayName("답변 저장 후 조회 테스트")
 	void findByIdTest() {
-		Answer answer = answerRepository.save(A1);
+		User questionWriter = userGenerator.savedUser(UserGenerator.questionWriter());
+		Question question = questionGenerator.savedQuestion(questionWriter);
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer answer = answerGenerator.savedAnswer(answerWriter, question, "answer contents");
 
 		Answer foundAnswer = answerRepository.findByIdAndDeletedFalse(answer.getId())
 			.orElseThrow(() -> new IllegalArgumentException("entity is not found"));
 
 		assertAll(
 			() -> assertThat(foundAnswer).isNotNull(),
-			() -> assertThat(foundAnswer.getId()).isEqualTo(answer.getId()),
-			() -> assertThat(foundAnswer.getContents()).isEqualTo(answer.getContents()),
-			() -> assertThat(foundAnswer.isDeleted()).isEqualTo(answer.isDeleted()),
-			() -> assertThat(foundAnswer.getQuestion()).isEqualTo(answer.getQuestion()),
-			() -> assertThat(foundAnswer.getWriter()).isEqualTo(answer.getWriter())
+			() -> assertThat(foundAnswer).isEqualTo(answer),
+			() -> assertThat(foundAnswer).isSameAs(answer)
 		);
 	}
 
 	@Test
-	@DisplayName("삭제 여부 true 로 변경 후 답변 조회 테스트")
+	@DisplayName("삭제 여부 true 로 변경 후 답변 조회 테스트 - dirty checking")
 	void findDeletedTest() {
 		// given
-		Answer answer = answerRepository.save(A1);
-		Long id = answer.getId();
+		User questionWriter = userGenerator.savedUser(UserGenerator.questionWriter());
+		Question question = questionGenerator.savedQuestion(questionWriter);
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer answer = answerGenerator.savedAnswer(answerWriter, question, "answer contents");
 
 		// when
 		answer.setDeleted(true);
-		Optional<Answer> byIdAndDeletedFalse = answerRepository.findByIdAndDeletedFalse(id);
+		entityManager.flush();
 
 		// then
-		assertAll(
-			() -> assertThat(byIdAndDeletedFalse).isEmpty(),
-			() -> assertThat(answer.isDeleted()).isTrue(),
-			() -> assertThat(answerRepository.findById(id)).isNotEmpty(),
-			() -> assertThat(answerRepository.findByIdAndDeletedFalse(id)).isEmpty()
-		);
+		assertThat(answer.isDeleted()).isTrue();
 	}
-
-	@Test
-	@DisplayName("답변 저장 후 삭제 테스트")
-	void findDeletedAnswerTest() {
-		// given
-		Answer answer = answerRepository.save(A1);
-		Long id = answer.getId();
-
-		// when
-		answerRepository.deleteById(id);
-
-		// then
-		assertAll(
-			() -> assertThat(answerRepository.findById(answer.getId())).isEmpty(),
-			() -> assertThat(answerRepository.findByIdAndDeletedFalse(answer.getId())).isEmpty()
-		);
-	}
-
 }

--- a/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
@@ -35,10 +35,8 @@ class AnswerRepositoryTest {
 			() -> assertThat(answer.getId()).isEqualTo(A1.getId()),
 			() -> assertThat(answer.getContents()).isEqualTo(A1.getContents()),
 			() -> assertThat(answer.isDeleted()).isEqualTo(A1.isDeleted()),
-			() -> assertThat(answer.getQuestionId()).isEqualTo(A1.getQuestionId()),
-			() -> assertThat(answer.getWriterId()).isEqualTo(A1.getWriterId()),
-			() -> assertThat(answer.getCreatedAt()).isEqualTo(A1.getCreatedAt()),
-			() -> assertThat(answer.getUpdatedAt()).isEqualTo(A1.getUpdatedAt())
+			() -> assertThat(answer.getQuestion()).isEqualTo(A1.getQuestion()),
+			() -> assertThat(answer.getWriter()).isEqualTo(A1.getWriter())
 		);
 	}
 
@@ -55,10 +53,8 @@ class AnswerRepositoryTest {
 			() -> assertThat(foundAnswer.getId()).isEqualTo(answer.getId()),
 			() -> assertThat(foundAnswer.getContents()).isEqualTo(answer.getContents()),
 			() -> assertThat(foundAnswer.isDeleted()).isEqualTo(answer.isDeleted()),
-			() -> assertThat(foundAnswer.getQuestionId()).isEqualTo(answer.getQuestionId()),
-			() -> assertThat(foundAnswer.getWriterId()).isEqualTo(answer.getWriterId()),
-			() -> assertThat(foundAnswer.getCreatedAt()).isEqualTo(answer.getCreatedAt()),
-			() -> assertThat(foundAnswer.getUpdatedAt()).isEqualTo(answer.getUpdatedAt())
+			() -> assertThat(foundAnswer.getQuestion()).isEqualTo(answer.getQuestion()),
+			() -> assertThat(foundAnswer.getWriter()).isEqualTo(answer.getWriter())
 		);
 	}
 

--- a/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
@@ -12,9 +12,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.test.context.TestConstructor;
 
+import qna.domain.generator.AnswerGenerator;
 import qna.domain.generator.QuestionGenerator;
 import qna.domain.generator.UserGenerator;
-import qna.domain.question.AnswerGenerator;
 import qna.domain.question.Question;
 import qna.domain.user.User;
 

--- a/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/answer/AnswerRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import javax.persistence.EntityManager;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -43,12 +42,6 @@ class AnswerRepositoryTest {
 		this.questionGenerator = questionGenerator;
 		this.userGenerator = userGenerator;
 		this.entityManager = entityManager;
-	}
-
-	// TODO 삭제
-	@BeforeEach
-	void setUp() {
-		answerRepository.deleteAllInBatch();
 	}
 
 	@Test

--- a/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
@@ -1,55 +1,103 @@
 package qna.domain.deletehistory;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static qna.domain.deletehistory.DeleteHistoryTest.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestConstructor;
+
+import qna.domain.ContentType;
+import qna.domain.answer.Answer;
+import qna.domain.generator.QuestionGenerator;
+import qna.domain.generator.UserGenerator;
+import qna.domain.question.AnswerGenerator;
+import qna.domain.question.Question;
+import qna.domain.user.User;
 
 @DataJpaTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Import({UserGenerator.class, QuestionGenerator.class, AnswerGenerator.class})
 @DisplayName("DeleteHistory Repository 테스트")
 class DeleteHistoryRepositoryTest {
 
-	@Autowired
-	private DeleteHistoryRepository deleteHistoryRepository;
+	private final DeleteHistoryRepository deleteHistoryRepository;
+	private final AnswerGenerator answerGenerator;
+	private final QuestionGenerator questionGenerator;
+	private final UserGenerator userGenerator;
+
+	public DeleteHistoryRepositoryTest(
+		DeleteHistoryRepository deleteHistoryRepository,
+		AnswerGenerator answerGenerator,
+		QuestionGenerator questionGenerator,
+		UserGenerator userGenerator
+	) {
+		this.deleteHistoryRepository = deleteHistoryRepository;
+		this.answerGenerator = answerGenerator;
+		this.questionGenerator = questionGenerator;
+		this.userGenerator = userGenerator;
+	}
 
 	@Test
-	@DisplayName("삭제 이력 저장 테스트")
-	void saveTest() {
-		DeleteHistory deleteHistory = deleteHistoryRepository.save(D1);
-		assertThat(deleteHistory).isNotNull();
+	@DisplayName("질문 삭제 이력 저장 테스트")
+	void saveQuestionTest() {
+		// given
+		User user = userGenerator.savedUser();
+		Question question = questionGenerator.savedQuestion(user);
+		DeleteHistory deleteHistory =
+			new DeleteHistory(ContentType.QUESTION, question.getId(), user, LocalDateTime.now());
+
+		// when
+		DeleteHistory actual = deleteHistoryRepository.save(deleteHistory);
+
+		// then
+		assertThat(actual).isNotNull();
+	}
+
+	@Test
+	@DisplayName("답변 삭제 이력 저장 테스트")
+	void saveAnswerTest() {
+		// given
+		User questionWriter = userGenerator.savedUser();
+		Question question = questionGenerator.savedQuestion(questionWriter);
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer answer = answerGenerator.savedAnswer(answerWriter, question, "answer contents");
+
+		DeleteHistory deleteHistory =
+			new DeleteHistory(ContentType.ANSWER, answer.getId(), answerWriter, LocalDateTime.now());
+
+		// when
+		DeleteHistory actual = deleteHistoryRepository.save(deleteHistory);
+
+		// then
+		assertThat(actual).isNotNull();
 	}
 
 	@Test
 	@DisplayName("삭제 이력 저장 후 조회 테스트")
 	void findByIdTest() {
-		DeleteHistory deleteHistory1 = deleteHistoryRepository.save(D1);
-		DeleteHistory deleteHistory2 = deleteHistoryRepository.save(D2);
+		// given
+		User questionWriter = userGenerator.savedUser();
+		Question question = questionGenerator.savedQuestion(questionWriter);
+		DeleteHistory questionDeleteHistory =
+			new DeleteHistory(ContentType.QUESTION, question.getId(), questionWriter, LocalDateTime.now());
+		DeleteHistory actualQuestionDeleteHistory = deleteHistoryRepository.save(questionDeleteHistory);
 
+		User answerWriter = userGenerator.savedUser(UserGenerator.answerWriter());
+		Answer answer = answerGenerator.savedAnswer(answerWriter, question, "answer contents");
+		DeleteHistory answerDeleteHistory =
+			new DeleteHistory(ContentType.ANSWER, answer.getId(), answerWriter, LocalDateTime.now());
+		DeleteHistory actualAnswerDeleteHistory = deleteHistoryRepository.save(answerDeleteHistory);
+
+		// when
 		List<DeleteHistory> deleteHistories = deleteHistoryRepository.findAll();
 
-		assertThat(deleteHistories).hasSize(2);
+		// then
+		assertThat(deleteHistories).hasSize(2)
+				.containsExactly(actualQuestionDeleteHistory, actualAnswerDeleteHistory);
 	}
-
-	@Test
-	@DisplayName("삭제 이력 저장 후 삭제 테스트")
-	void deleteTest() {
-		DeleteHistory deleteHistory1 = deleteHistoryRepository.save(D1);
-		DeleteHistory deleteHistory2 = deleteHistoryRepository.save(D2);
-
-		deleteHistoryRepository.delete(deleteHistory1);
-
-		List<DeleteHistory> deleteHistories = deleteHistoryRepository.findAll();
-
-		assertAll(
-			() -> assertThat(deleteHistories).hasSize(1),
-			() -> assertThat(deleteHistories).containsExactly(deleteHistory2)
-		);
-	}
-
 }

--- a/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
@@ -13,9 +13,9 @@ import org.springframework.test.context.TestConstructor;
 
 import qna.domain.ContentType;
 import qna.domain.answer.Answer;
+import qna.domain.generator.AnswerGenerator;
 import qna.domain.generator.QuestionGenerator;
 import qna.domain.generator.UserGenerator;
-import qna.domain.question.AnswerGenerator;
 import qna.domain.question.Question;
 import qna.domain.user.User;
 

--- a/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/deletehistory/DeleteHistoryRepositoryTest.java
@@ -6,7 +6,6 @@ import static qna.domain.deletehistory.DeleteHistoryTest.*;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +17,6 @@ class DeleteHistoryRepositoryTest {
 
 	@Autowired
 	private DeleteHistoryRepository deleteHistoryRepository;
-
-	@BeforeEach
-	void setUp() {
-		deleteHistoryRepository.deleteAllInBatch();
-	}
 
 	@Test
 	@DisplayName("삭제 이력 저장 테스트")

--- a/src/test/java/qna/domain/deletehistory/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/deletehistory/DeleteHistoryTest.java
@@ -3,12 +3,13 @@ package qna.domain.deletehistory;
 import java.time.LocalDateTime;
 
 import qna.domain.ContentType;
+import qna.domain.generator.UserGenerator;
 
 class DeleteHistoryTest {
 	public static final DeleteHistory D1 =
-		new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+		new DeleteHistory(ContentType.QUESTION, 1L, UserGenerator.questionWriter(), LocalDateTime.now());
 	public static final DeleteHistory D2 =
-		new DeleteHistory(ContentType.ANSWER, 2L, 1L, LocalDateTime.now());
+		new DeleteHistory(ContentType.ANSWER, 2L, UserGenerator.questionWriter(), LocalDateTime.now());
 
 
 }

--- a/src/test/java/qna/domain/generator/AnswerGenerator.java
+++ b/src/test/java/qna/domain/generator/AnswerGenerator.java
@@ -1,7 +1,8 @@
-package qna.domain.question;
+package qna.domain.generator;
 
 import qna.domain.answer.Answer;
 import qna.domain.answer.AnswerRepository;
+import qna.domain.question.Question;
 import qna.domain.user.User;
 
 public class AnswerGenerator {

--- a/src/test/java/qna/domain/generator/QuestionGenerator.java
+++ b/src/test/java/qna/domain/generator/QuestionGenerator.java
@@ -1,0 +1,22 @@
+package qna.domain.generator;
+
+import qna.domain.question.Question;
+import qna.domain.question.QuestionRepository;
+import qna.domain.user.User;
+
+public class QuestionGenerator {
+
+	private final QuestionRepository questionRepository;
+
+	public QuestionGenerator(QuestionRepository questionRepository) {
+		this.questionRepository = questionRepository;
+	}
+
+	public static Question question(User writer) {
+		return new Question("title", "contents").writeBy(writer);
+	}
+
+	public Question savedQuestion(User writer) {
+		return questionRepository.saveAndFlush(question(writer));
+	}
+}

--- a/src/test/java/qna/domain/generator/UserGenerator.java
+++ b/src/test/java/qna/domain/generator/UserGenerator.java
@@ -1,0 +1,33 @@
+package qna.domain.generator;
+
+import qna.domain.user.User;
+import qna.domain.user.UserRepository;
+
+public class UserGenerator {
+
+	private final UserRepository userRepository;
+
+	public UserGenerator(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	public static User questionWriter() {
+		return new User("hahoho87", "password", "질문자", "hahoho87@email.com");
+	}
+
+	public static User answerWriter() {
+		return new User("hahaha90", "password", "답변자", "hahaha90@email.com");
+	}
+
+	private static User of(String userId, String password, String name, String email) {
+		return new User(userId, password, name, email);
+	}
+
+	public User savedUser() {
+		return userRepository.saveAndFlush(questionWriter());
+	}
+
+	public User savedUser(User user) {
+		return userRepository.saveAndFlush(user);
+	}
+}

--- a/src/test/java/qna/domain/question/AnswerGenerator.java
+++ b/src/test/java/qna/domain/question/AnswerGenerator.java
@@ -1,0 +1,22 @@
+package qna.domain.question;
+
+import qna.domain.answer.Answer;
+import qna.domain.answer.AnswerRepository;
+import qna.domain.user.User;
+
+public class AnswerGenerator {
+
+	private final AnswerRepository answerRepository;
+
+	public AnswerGenerator(AnswerRepository answerRepository) {
+		this.answerRepository = answerRepository;
+	}
+
+	public static Answer answer(User writer, Question question, String contents) {
+		return new Answer(writer, question, contents);
+	}
+
+	public Answer savedAnswer(User writer, Question question, String contents) {
+		return answerRepository.saveAndFlush(answer(writer, question, contents));
+	}
+}

--- a/src/test/java/qna/domain/question/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/question/QuestionRepositoryTest.java
@@ -131,7 +131,7 @@ class QuestionRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("삭제 여부 true 로 변경 후 조회 테스트")
+	@DisplayName("삭제 여부 true 로 변경 후 조회 테스트 - dirty checking")
 	void deleteTest() {
 		// given
 		User writer = userGenerator.savedUser();

--- a/src/test/java/qna/domain/question/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/question/QuestionRepositoryTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javax.persistence.EntityManager;
 
 import org.hibernate.proxy.HibernateProxy;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -41,11 +40,6 @@ class QuestionRepositoryTest {
 		this.questionGenerator = questionGenerator;
 		this.userGenerator = userGenerator;
 		this.entityManager = entityManager;
-	}
-
-	@BeforeEach
-	void setUp() {
-		questionRepository.deleteAllInBatch();
 	}
 
 	@Test

--- a/src/test/java/qna/domain/question/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/question/QuestionRepositoryTest.java
@@ -40,7 +40,7 @@ class QuestionRepositoryTest {
 			() -> assertThat(question.getTitle()).isEqualTo(Q1.getTitle()),
 			() -> assertThat(question.getContents()).isEqualTo(Q1.getContents()),
 			() -> assertThat(question.isDeleted()).isEqualTo(Q1.isDeleted()),
-			() -> assertThat(question.getWriterId()).isEqualTo(Q1.getWriterId())
+			() -> assertThat(question.getWriter()).isEqualTo(Q1.getWriter())
 		);
 	}
 
@@ -58,7 +58,7 @@ class QuestionRepositoryTest {
 			() -> assertThat(actual.getTitle()).isEqualTo(question.getTitle()),
 			() -> assertThat(actual.getContents()).isEqualTo(question.getContents()),
 			() -> assertThat(actual.isDeleted()).isEqualTo(question.isDeleted()),
-			() -> assertThat(actual.getWriterId()).isEqualTo(question.getWriterId())
+			() -> assertThat(actual.getWriter()).isEqualTo(question.getWriter())
 		);
 	}
 

--- a/src/test/java/qna/domain/question/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/question/QuestionRepositoryTest.java
@@ -40,9 +40,7 @@ class QuestionRepositoryTest {
 			() -> assertThat(question.getTitle()).isEqualTo(Q1.getTitle()),
 			() -> assertThat(question.getContents()).isEqualTo(Q1.getContents()),
 			() -> assertThat(question.isDeleted()).isEqualTo(Q1.isDeleted()),
-			() -> assertThat(question.getWriterId()).isEqualTo(Q1.getWriterId()),
-			() -> assertThat(question.getCreatedAt()).isEqualTo(Q1.getCreatedAt()),
-			() -> assertThat(question.getUpdatedAt()).isEqualTo(Q1.getUpdatedAt())
+			() -> assertThat(question.getWriterId()).isEqualTo(Q1.getWriterId())
 		);
 	}
 
@@ -60,9 +58,7 @@ class QuestionRepositoryTest {
 			() -> assertThat(actual.getTitle()).isEqualTo(question.getTitle()),
 			() -> assertThat(actual.getContents()).isEqualTo(question.getContents()),
 			() -> assertThat(actual.isDeleted()).isEqualTo(question.isDeleted()),
-			() -> assertThat(actual.getWriterId()).isEqualTo(question.getWriterId()),
-			() -> assertThat(actual.getCreatedAt()).isEqualTo(question.getCreatedAt()),
-			() -> assertThat(actual.getUpdatedAt()).isEqualTo(question.getUpdatedAt())
+			() -> assertThat(actual.getWriterId()).isEqualTo(question.getWriterId())
 		);
 	}
 

--- a/src/test/java/qna/domain/question/QuestionTest.java
+++ b/src/test/java/qna/domain/question/QuestionTest.java
@@ -1,8 +1,46 @@
 package qna.domain.question;
 
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import qna.domain.answer.Answer;
+import qna.domain.generator.UserGenerator;
 import qna.domain.user.UserTest;
 
 public class QuestionTest {
-    public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
-    public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+	public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
+	public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+	@Test
+	@DisplayName("새로운 답변 등록 시 답변 목록 추가 테스트")
+	void addAnswer() {
+		// Given
+		Question question = new Question("title", "contents");
+		question.writeBy(UserGenerator.questionWriter());
+		Answer answer = new Answer(UserGenerator.answerWriter(), question, "contents");
+
+		// When
+		question.addAnswer(answer);
+
+		// Then
+		assertThat(question.getAnswers()).containsExactly(answer);
+	}
+
+	@Test
+	@DisplayName("동일 답변 중복 등록 시 목록 추가 제외 테스트")
+	void addDuplicateAnswerTest() {
+		// Given
+		Question question = new Question("title", "contents");
+		question.writeBy(UserGenerator.questionWriter());
+		Answer answer = new Answer(UserGenerator.answerWriter(), question, "contents");
+
+		// When
+		question.addAnswer(answer);
+		question.addAnswer(answer);
+
+		// Then
+		assertThat(question.getAnswers()).containsExactly(answer);
+	}
 }

--- a/src/test/java/qna/domain/user/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/user/UserRepositoryTest.java
@@ -6,7 +6,6 @@ import static qna.domain.user.UserTest.*;
 
 import javax.persistence.EntityManager;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -29,11 +28,6 @@ class UserRepositoryTest {
 		this.userRepository = userRepository;
 		this.userGenerator = userGenerator;
 		this.entityManager = entityManager;
-	}
-
-	@BeforeEach
-	void setUp() {
-		userRepository.deleteAllInBatch();
 	}
 
 	@Test

--- a/src/test/java/qna/domain/user/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/user/UserRepositoryTest.java
@@ -4,18 +4,32 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static qna.domain.user.UserTest.*;
 
+import javax.persistence.EntityManager;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestConstructor;
+
+import qna.domain.generator.UserGenerator;
 
 @DataJpaTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Import(UserGenerator.class)
 @DisplayName("User Repository 테스트")
 class UserRepositoryTest {
 
-	@Autowired
-	private UserRepository userRepository;
+	private final UserRepository userRepository;
+	private final UserGenerator userGenerator;
+	private final EntityManager entityManager;
+
+	public UserRepositoryTest(UserRepository userRepository, UserGenerator userGenerator, EntityManager entityManager) {
+		this.userRepository = userRepository;
+		this.userGenerator = userGenerator;
+		this.entityManager = entityManager;
+	}
 
 	@BeforeEach
 	void setUp() {
@@ -25,16 +39,11 @@ class UserRepositoryTest {
 	@Test
 	@DisplayName("회원 저장 테스트")
 	void saveTest() {
-		User user = userRepository.save(JAVAJIGI);
+		User user = userRepository.save(UserGenerator.questionWriter());
 
 		assertAll(
 			() -> assertThat(user).isNotNull(),
-			() -> assertThat(user.getId()).isNotNull(),
-			() -> assertThat(user.getId()).isEqualTo(JAVAJIGI.getId()),
-			() -> assertThat(user.getUserId()).isEqualTo(JAVAJIGI.getUserId()),
-			() -> assertThat(user.getPassword()).isEqualTo(JAVAJIGI.getPassword()),
-			() -> assertThat(user.getName()).isEqualTo(JAVAJIGI.getName()),
-			() -> assertThat(user.getEmail()).isEqualTo(JAVAJIGI.getEmail())
+			() -> assertThat(user.getId()).isNotNull()
 		);
 	}
 
@@ -52,7 +61,8 @@ class UserRepositoryTest {
 			() -> assertThat(actual.getUserId()).isEqualTo(user.getUserId()),
 			() -> assertThat(actual.getPassword()).isEqualTo(user.getPassword()),
 			() -> assertThat(actual.getName()).isEqualTo(user.getName()),
-			() -> assertThat(actual.getEmail()).isEqualTo(user.getEmail())
+			() -> assertThat(actual.getEmail()).isEqualTo(user.getEmail()),
+			() -> assertThat(actual).isSameAs(user)
 		);
 	}
 
@@ -70,10 +80,25 @@ class UserRepositoryTest {
 			() -> assertThat(actual.getUserId()).isEqualTo(user.getUserId()),
 			() -> assertThat(actual.getPassword()).isEqualTo(user.getPassword()),
 			() -> assertThat(actual.getName()).isEqualTo(user.getName()),
-			() -> assertThat(actual.getEmail()).isEqualTo(user.getEmail())
+			() -> assertThat(actual.getEmail()).isEqualTo(user.getEmail()),
+			() -> assertThat(actual).isSameAs(user)
 		);
 	}
 
+	@Test
+	@DisplayName("회원 정보 수정 테스트 - dirty check 이용")
+	void updateUserTest() {
+		User user = userGenerator.savedUser();
+		String newName = "newName";
+		String newEmail = "newEmail";
+		User target = new User(user.getId(), user.getUserId(), user.getPassword(), newName, newEmail);
 
+		user.update(user, target);
+		entityManager.flush();
 
+		assertAll(
+			() -> assertThat(user.getName()).isEqualTo(newName),
+			() -> assertThat(user.getEmail()).isEqualTo(newEmail)
+		);
+	}
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -95,7 +95,7 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
                 new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -95,8 +95,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter().getId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -52,7 +52,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        when(answerRepository.findByQuestionAndDeletedFalse(question)).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -72,7 +72,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
+        when(answerRepository.findByQuestionAndDeletedFalse(question)).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -87,7 +87,7 @@ class QnaServiceTest {
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
+        when(answerRepository.findByQuestionAndDeletedFalse(question)).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);
@@ -96,7 +96,7 @@ class QnaServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
민제님 안녕하세요! 백경윤입니다.

피드백 반영 및 Step2 미션 제출합니다!!

피드백
- [updatable, insertable](https://github.com/next-step/jwp-qna/pull/570#discussion_r1010369647)
   - Id 를 읽기 전용으로 만들고 싶어 해당 속성을 써 봤는데, 더 찾아보니 JPA 에서 기본적으로 기본키의 변경은 불가하네요.. 고민이나 학습 없이 느낌대로 가져다 썼다가 바로 적발(?) 되었습니다 😂 
- [getCreateAt](https://github.com/next-step/jwp-qna/pull/570#discussion_r1010379136)  
   - `JPA auditing` 에 관해서 디버깅 해보고 싶어 `getCreatedAT` 메서드를 만들었다가 삭제하지 않았습니다. 
- [setUp 메서드 관련](https://github.com/next-step/jwp-qna/pull/570#discussion_r1010384398) 
   - 말씀 듣고 확인해보니 `@JpaDataTest` 어노테이션에 `@Transactional` 어노테이션이 포함 되어 있네요 😂 말씀대로 굳이 메서드마다 데이터 삭제 할 필요가 없을 것 같아 해당 메서드들은 삭제했습니다!

Step2
- 상수화 된 객체로 테스트를 진행하다보니, 한 테스트 케이스에서는 괜찮은데, 여러 테스트 케이스 실행 시 데이터 공유로 인해 제대로 된 테스트 진행이 어려워 각 엔티티를 생성할 수 있는 `Generator` 을 만들어 활용했습니다.
- 연관 관계 설정 시, 양방향 관계를 최소화 하고, 양방향 연관 관계가 필요 하면 연관관계 편의 메서드를 생성했습니다.
- JPA 관련 (`dirty checking`,  `영속성`) 관련 테스트를 추가했습니다.

- 질문
   - `JPA auditing` 을 이리저리(?) 살펴보는 와중에, `Answer` 의 삭제 여부를 변경함과 동시에 `DeleteHistory` 를 생성하는데 `Answer` 의 `updatedAt` 시간과 `DeleteHistory` 의 `createdAt` 시간이 동일하지 않다는 것을 알게 되었습니다. 찾아보니 `persist` 할 때에 `AuditingEntityListner` 에 의해서 현재 시점을 넣어 주던데, 만약 비지니스적으로 둘이 같아야 한다면 커스텀한 `AuditingEntityListener` 을 만들거나 `auditing` 을 사용하지 않고, 같은 값으로 들어갈 수 있게 처리해줘야 할까요?? 아니면 제가 모르는 유용한 옵션같은 것이 있는지 궁금합니다!