### PR TITLE
JPA Step2: 연관 관계 매핑 리뷰 요청 드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,75 @@ create table user
 alter table user
     add constraint UK_a3imlf41l37utmxiquukk8ajc unique (user_id)
 ```
+
+## 2단계 - 연관 관계 매핑
+
+### 요구 사항
+- QnA 서비스를 만들어가면서 JPA로 실제 도메인 모델을 어떻게 구성하고 객체와 테이블을 어떻게 매핑해야 하는지 알아본다.
+  - 객체의 참조와 테이블의 외래 키를 매핑해서 객체에서는 참조를 사용하고 테이블에서는 외래 키를 사용할 수 있도록 한다.
+
+### 힌트
+- 이전 단계에서 엔티티 설계가 이상하다는 생각이 들었다면 객체 지향 설계를 의식하는 개발자고, 그렇지 않고 자연스러웠다면 데이터 중심의 개발자일 것이다.
+  객체 지향 설계는 각각의 객체가 맡은 역할과 책임이 있고 관련 있는 객체끼리 참조하도록 설계해야 한다.
+
+<pre>
+Question question = findQuestionById(questionId);
+List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
+</pre>
+
+- 위 방식은 객체 설계를 테이블 설계에 맞춘 방법이다. 특히 테이블의 외래 키를 객체에 그대로 가져온 부분이 문제다.
+  왜냐하면 관계형 데이터베이스는 연관된 객체를 찾을 때 외래 키를 사용해서 조인하면 되지만 객체에는 조인이라는 기능이 없다.
+  객체는 연관된 객체를 찾을 때 참조를 사용해야 한다.
+
+<pre>
+Question question = findQuestionById(questionId);
+List<Answer> answers = question.getAnswers();
+</pre>
+
+아래의 DDL을 보고 유추한다.
+- H2
+
+```sql
+alter table answer
+    add constraint fk_answer_to_question
+        foreign key (question_id)
+            references question
+
+alter table answer
+    add constraint fk_answer_writer
+        foreign key (writer_id)
+            references user
+
+alter table delete_history
+    add constraint fk_delete_history_to_user
+        foreign key (deleted_by_id)
+            references user
+
+alter table question
+    add constraint fk_question_writer
+        foreign key (writer_id)
+            references user
+```
+
+- MySQL
+```sql
+alter table answer
+    add constraint fk_answer_to_question
+        foreign key (question_id)
+            references question (id)
+
+alter table answer
+    add constraint fk_answer_writer
+        foreign key (writer_id)
+            references user (id)
+
+alter table delete_history
+    add constraint fk_delete_history_to_user
+        foreign key (deleted_by_id)
+            references user (id)
+
+alter table question
+    add constraint fk_question_writer
+        foreign key (writer_id)
+            references user (id)
+```

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -11,10 +11,10 @@ public class Answer extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id")
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
     private User writer;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
     @Lob
     private String contents;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -79,8 +79,8 @@ public class Answer extends BaseEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writer=" + writer +
-                ", question=" + question +
+                ", writerId=" + writer.getId() +
+                ", questionId=" + question.getId() +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -10,9 +10,11 @@ import java.util.Objects;
 public class Answer extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
     private User writer;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     private Question question;
     @Lob
     private String contents;

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -8,11 +8,12 @@ import java.util.Objects;
 
 @Entity
 public class Answer extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long writerId;
-    private Long questionId;
+    @ManyToOne
+    private User writer;
+    @ManyToOne
+    private Question question;
     @Lob
     private String contents;
     @Column(nullable = false)
@@ -33,31 +34,31 @@ public class Answer extends BaseEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     protected Answer() {}
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
         return id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public Long getQuestionId() {
-        return questionId;
+    public Question getQuestion() {
+        return question;
     }
 
     public String getContents() {
@@ -76,8 +77,8 @@ public class Answer extends BaseEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
+                ", writer=" + writer +
+                ", question=" + question +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -69,7 +69,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedBy=" + deletedBy +
+                ", deletedById=" + deletedBy.getId() +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -12,7 +12,7 @@ public class DeleteHistory {
     private ContentType contentType;
     private Long contentId;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delete_user_id")
+    @JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
     private User deletedBy;
     private LocalDateTime createDate = LocalDateTime.now();
 

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -11,13 +11,14 @@ public class DeleteHistory {
     @Enumerated(EnumType.STRING)
     private ContentType contentType;
     private Long contentId;
-    private Long deletedById;
+    @ManyToOne
+    private User deletedBy;
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -37,8 +38,8 @@ public class DeleteHistory {
         return contentId;
     }
 
-    public Long getDeletedById() {
-        return deletedById;
+    public User getDeletedBy() {
+        return deletedBy;
     }
 
     public LocalDateTime getCreateDate() {
@@ -53,12 +54,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&
                 Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+                Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedBy);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deletedBy=" + deletedBy +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -11,7 +11,8 @@ public class DeleteHistory {
     @Enumerated(EnumType.STRING)
     private ContentType contentType;
     private Long contentId;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delete_user_id")
     private User deletedBy;
     private LocalDateTime createDate = LocalDateTime.now();
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -11,7 +11,7 @@ public class Question extends BaseEntity  {
     @Lob
     private String contents;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id")
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
     @Column(nullable = false)
     private boolean deleted = false;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -10,7 +10,8 @@ public class Question extends BaseEntity  {
     private String title;
     @Lob
     private String contents;
-    private Long writerId;
+    @ManyToOne
+    private User writer;
     @Column(nullable = false)
     private boolean deleted = false;
 
@@ -29,12 +30,12 @@ public class Question extends BaseEntity  {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -45,8 +46,8 @@ public class Question extends BaseEntity  {
         return id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public boolean isDeleted() {
@@ -71,7 +72,7 @@ public class Question extends BaseEntity  {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -73,7 +73,7 @@ public class Question extends BaseEntity  {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writer=" + writer +
+                ", writerId=" + writer.getId() +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -10,7 +10,8 @@ public class Question extends BaseEntity  {
     private String title;
     @Lob
     private String contents;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
     private User writer;
     @Column(nullable = false)
     private boolean deleted = false;

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,9 +1,6 @@
 package qna.domain;
 
-import qna.UnAuthorizedException;
-
 import javax.persistence.*;
-import java.util.Objects;
 
 @Entity
 public class User extends BaseEntity {

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -50,10 +50,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,5 @@ spring.datasource.username=sa
 spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.show-sql=true
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -8,9 +8,6 @@ import qna.UnAuthorizedException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
-
     @DisplayName("작성자가 없는 답변은 예외가 발생한다")
     @Test
     void no_writer_exception_test() {

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -4,5 +4,5 @@ import java.time.LocalDateTime;
 
 public class DeleteHistoryTest {
     public static final DeleteHistory DH1 =
-            new DeleteHistory(ContentType.ANSWER, 1L, 1L, LocalDateTime.now());
+            new DeleteHistory(ContentType.ANSWER, 1L, UserTest.JAVAJIGI, LocalDateTime.now());
 }

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,8 +1,0 @@
-package qna.domain;
-
-import java.time.LocalDateTime;
-
-public class DeleteHistoryTest {
-    public static final DeleteHistory DH1 =
-            new DeleteHistory(ContentType.ANSWER, 1L, UserTest.JAVAJIGI, LocalDateTime.now());
-}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -2,5 +2,4 @@ package qna.domain;
 
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
-    public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
 }

--- a/src/test/java/qna/fixture/TestAnswerFactory.java
+++ b/src/test/java/qna/fixture/TestAnswerFactory.java
@@ -1,0 +1,11 @@
+package qna.fixture;
+
+import qna.domain.Answer;
+import qna.domain.Question;
+import qna.domain.User;
+
+public class TestAnswerFactory {
+    public static Answer create(User writer, Question question) {
+        return new Answer(writer, question, "contents");
+    }
+}

--- a/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
+++ b/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
@@ -1,0 +1,13 @@
+package qna.fixture;
+
+import qna.domain.ContentType;
+import qna.domain.DeleteHistory;
+import qna.domain.User;
+
+import java.time.LocalDateTime;
+
+public class TestDeleteHistoryFactory {
+    public static DeleteHistory create(User deleteBy) {
+        return new DeleteHistory(ContentType.QUESTION,1L , deleteBy, LocalDateTime.now());
+    }
+}

--- a/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
+++ b/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 
 public class TestDeleteHistoryFactory {
     public static DeleteHistory create(User deleteBy) {
-        return new DeleteHistory(ContentType.QUESTION,1L , deleteBy, LocalDateTime.now());
+        return new DeleteHistory(ContentType.QUESTION, 1L, deleteBy, LocalDateTime.now());
     }
 }

--- a/src/test/java/qna/fixture/TestQuestionFactory.java
+++ b/src/test/java/qna/fixture/TestQuestionFactory.java
@@ -1,0 +1,12 @@
+package qna.fixture;
+
+import qna.domain.Question;
+import qna.domain.User;
+
+public class TestQuestionFactory {
+    public static Question create(User writer) {
+        Question question = new Question("title", "contents");
+        question.writeBy(writer);
+        return question;
+    }
+}

--- a/src/test/java/qna/fixture/TestUserFactory.java
+++ b/src/test/java/qna/fixture/TestUserFactory.java
@@ -1,0 +1,9 @@
+package qna.fixture;
+
+import qna.domain.User;
+
+public class TestUserFactory {
+    public static User create(String name) {
+        return new User(name, "password", "userId", "email");
+    }
+}

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
 class AnswerRepositoryTest {
@@ -63,7 +64,7 @@ class AnswerRepositoryTest {
 
         Answer result = answerRepository.findByIdAndDeletedFalse(expect.getId()).get();
 
-        assertThat(result == expect).isTrue();
+        assertEquals(expect, result);
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByIdAndDeletedFalse 함수로 조회할 수 없다")
@@ -88,7 +89,7 @@ class AnswerRepositoryTest {
 
         Answer result = answerRepository.findByQuestionIdAndDeletedFalse(expect.getQuestion().getId()).get(0);
 
-        assertThat(expect == result).isTrue();
+        assertEquals(expect, result);
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByQuestionIdAndDeletedFalse 함수로 조회할 수 없다")

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -44,14 +44,14 @@ class AnswerRepositoryTest {
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
         Answer expect = TestAnswerFactory.create(writer, question);
 
-        Answer actual = answerRepository.save(expect);
+        Answer result = answerRepository.save(expect);
 
         assertAll(
-                () -> assertThat(actual.getId()).isNotNull(),
-                () -> assertThat(actual.isDeleted()).isEqualTo(expect.isDeleted()),
-                () -> assertThat(actual.getContents()).isEqualTo(expect.getContents()),
-                () -> assertThat(actual.getQuestion()).isEqualTo(expect.getQuestion()),
-                () -> assertThat(actual.getWriter()).isEqualTo(expect.getWriter())
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.isDeleted()).isEqualTo(expect.isDeleted()),
+                () -> assertThat(result.getContents()).isEqualTo(expect.getContents()),
+                () -> assertThat(result.getQuestion()).isEqualTo(expect.getQuestion()),
+                () -> assertThat(result.getWriter()).isEqualTo(expect.getWriter())
         );
     }
 

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -28,8 +28,8 @@ class AnswerRepositoryTest {
                 () -> assertThat(result.getId()).isNotNull(),
                 () -> assertThat(result.isDeleted()).isEqualTo(A1.isDeleted()),
                 () -> assertThat(result.getContents()).isEqualTo(A1.getContents()),
-                () -> assertThat(result.getQuestionId()).isEqualTo(A1.getQuestionId()),
-                () -> assertThat(result.getWriterId()).isEqualTo(A1.getWriterId())
+                () -> assertThat(result.getQuestion()).isEqualTo(A1.getQuestion()),
+                () -> assertThat(result.getWriter()).isEqualTo(A1.getWriter())
         );
     }
 
@@ -37,19 +37,17 @@ class AnswerRepositoryTest {
     @Test
     void findById() {
         Answer expect = answerRepository.save(A1);
-
         Answer result = answerRepository.findByIdAndDeletedFalse(expect.getId()).get();
-
         assertThat(expect == result).isTrue();
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByIdAndDeletedFalse 함수로 조회할 수 없다")
     @Test
     void findDeletedById() {
-        Answer answer = answerRepository.save(A2);
-        answer.setDeleted(true);
+        Answer actual = answerRepository.save(A2);
+        actual.setDeleted(true);
 
-        Optional<Answer> result = answerRepository.findByIdAndDeletedFalse(answer.getId());
+        Optional<Answer> result = answerRepository.findByIdAndDeletedFalse(actual.getId());
 
         assertThat(result).isNotPresent();
     }
@@ -57,20 +55,20 @@ class AnswerRepositoryTest {
     @DisplayName("질문의 id로 조회할 수 있다")
     @Test
     void findByQuestionId() {
-        Answer expect = answerRepository.save(A1);
+        Answer actual = answerRepository.save(A1);
 
-        Answer result = answerRepository.findByQuestionIdAndDeletedFalse(expect.getQuestionId()).get(0);
+        Answer result = answerRepository.findByQuestionIdAndDeletedFalse(actual.getQuestion().getId()).get(0);
 
-        assertThat(expect == result).isTrue();
+        assertThat(actual == result).isTrue();
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByQuestionIdAndDeletedFalse 함수로 조회할 수 없다")
     @Test
     void findDeletedByQuestionId() {
-        Answer answer = answerRepository.save(A2);
-        answer.setDeleted(true);
+        Answer actual = answerRepository.save(A2);
+        actual.setDeleted(true);
 
-        List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(answer.getQuestionId());
+        List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(actual.getQuestion().getId());
 
         assertThat(result).hasSize(0);
     }

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -40,13 +40,6 @@ class AnswerRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    @BeforeEach
-    void clear() {
-        answerRepository.deleteAll();
-        userRepository.deleteAll();
-        questionRepository.deleteAll();
-    }
-
     @DisplayName("답변을 저장할 수 있다")
     @Test
     void save() {
@@ -117,7 +110,6 @@ class AnswerRepositoryTest {
 
     @DisplayName("답변 조회시 writer, question이 지연로딩 되는지 확인한다")
     @Test
-    @Transactional
     void lazyLoadingTest() {
         PersistenceUnitUtil persistenceUnitUtil = factory.getPersistenceUnitUtil();
         User writer = userRepository.save(TestUserFactory.create("writer"));

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -1,53 +1,80 @@
 package qna.repository;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import qna.domain.Answer;
+import qna.domain.Question;
+import qna.domain.User;
+import qna.fixture.TestAnswerFactory;
+import qna.fixture.TestQuestionFactory;
+import qna.fixture.TestUserFactory;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static qna.domain.AnswerTest.A1;
-import static qna.domain.AnswerTest.A2;
 
 @DataJpaTest
 class AnswerRepositoryTest {
     @Autowired
     private AnswerRepository answerRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @BeforeEach
+    void clear() {
+        answerRepository.deleteAll();
+        userRepository.deleteAll();
+        questionRepository.deleteAll();
+    }
+
     @DisplayName("답변을 저장할 수 있다")
     @Test
     void save() {
-        Answer result = answerRepository.save(A1);
+        User writer = userRepository.save(TestUserFactory.create("writer"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
+        Answer expect = TestAnswerFactory.create(writer, question);
+
+        Answer actual = answerRepository.save(expect);
 
         assertAll(
-                () -> assertThat(result.getId()).isNotNull(),
-                () -> assertThat(result.isDeleted()).isEqualTo(A1.isDeleted()),
-                () -> assertThat(result.getContents()).isEqualTo(A1.getContents()),
-                () -> assertThat(result.getQuestion()).isEqualTo(A1.getQuestion()),
-                () -> assertThat(result.getWriter()).isEqualTo(A1.getWriter())
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.isDeleted()).isEqualTo(expect.isDeleted()),
+                () -> assertThat(actual.getContents()).isEqualTo(expect.getContents()),
+                () -> assertThat(actual.getQuestion()).isEqualTo(expect.getQuestion()),
+                () -> assertThat(actual.getWriter()).isEqualTo(expect.getWriter())
         );
     }
 
     @DisplayName("id로 조회할 수 있다")
     @Test
     void findById() {
-        Answer expect = answerRepository.save(A1);
+        User writer = userRepository.save(TestUserFactory.create("writer"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
+        Answer expect = answerRepository.save(TestAnswerFactory.create(writer, question));
+
         Answer result = answerRepository.findByIdAndDeletedFalse(expect.getId()).get();
-        assertThat(expect == result).isTrue();
+
+        assertThat(result == expect).isTrue();
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByIdAndDeletedFalse 함수로 조회할 수 없다")
     @Test
     void findDeletedById() {
-        Answer actual = answerRepository.save(A2);
-        actual.setDeleted(true);
+        User writer = userRepository.save(TestUserFactory.create("writer"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
+        Answer answer = answerRepository.save(TestAnswerFactory.create(writer, question));
+        answer.setDeleted(true);
 
-        Optional<Answer> result = answerRepository.findByIdAndDeletedFalse(actual.getId());
+        Optional<Answer> result = answerRepository.findByIdAndDeletedFalse(answer.getId());
 
         assertThat(result).isNotPresent();
     }
@@ -55,20 +82,24 @@ class AnswerRepositoryTest {
     @DisplayName("질문의 id로 조회할 수 있다")
     @Test
     void findByQuestionId() {
-        Answer actual = answerRepository.save(A1);
+        User writer = userRepository.save(TestUserFactory.create("writer"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
+        Answer expect = answerRepository.save(TestAnswerFactory.create(writer, question));
 
-        Answer result = answerRepository.findByQuestionIdAndDeletedFalse(actual.getQuestion().getId()).get(0);
+        Answer result = answerRepository.findByQuestionIdAndDeletedFalse(expect.getQuestion().getId()).get(0);
 
-        assertThat(actual == result).isTrue();
+        assertThat(expect == result).isTrue();
     }
 
     @DisplayName("답변이 삭제되었을 경우, findByQuestionIdAndDeletedFalse 함수로 조회할 수 없다")
     @Test
     void findDeletedByQuestionId() {
-        Answer actual = answerRepository.save(A2);
-        actual.setDeleted(true);
+        User writer = userRepository.save(TestUserFactory.create("writer"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
+        Answer answer = answerRepository.save(TestAnswerFactory.create(writer, question));
+        answer.setDeleted(true);
 
-        List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(actual.getQuestion().getId());
+        List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(answer.getQuestion().getId());
 
         assertThat(result).hasSize(0);
     }

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -12,7 +12,7 @@ import qna.fixture.TestUserFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 class DeleteHistoryRepositoryTest {
     @Autowired
     private DeleteHistoryRepository deleteHistoryRepository;

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -5,26 +5,33 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import qna.domain.DeleteHistory;
+import qna.domain.User;
+import qna.fixture.TestDeleteHistoryFactory;
+import qna.fixture.TestUserFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static qna.domain.DeleteHistoryTest.DH1;
 
 @DataJpaTest
 class DeleteHistoryRepositoryTest {
     @Autowired
     private DeleteHistoryRepository deleteHistoryRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @DisplayName("삭제 이력을 저장할 수 있다")
     @Test
     void save() {
-        DeleteHistory actual = deleteHistoryRepository.save(DH1);
+        User deleteBy = userRepository.save(TestUserFactory.create("서정국"));
+        DeleteHistory expect = TestDeleteHistoryFactory.create(deleteBy);
+        DeleteHistory result = deleteHistoryRepository.save(expect);
 
         assertAll(
-                () -> assertThat(actual.getId()).isNotNull(),
-                () -> assertThat(actual.getContentId()).isEqualTo(DH1.getContentId()),
-                () -> assertThat(actual.getDeletedBy()).isEqualTo(DH1.getDeletedBy()),
-                () -> assertThat(actual.getCreateDate()).isEqualTo(DH1.getCreateDate())
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.getContentId()).isEqualTo(expect.getContentId()),
+                () -> assertThat(result.getDeletedBy()).isEqualTo(expect.getDeletedBy()),
+                () -> assertThat(result.getCreateDate()).isEqualTo(expect.getCreateDate())
         );
     }
 }

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -18,13 +18,13 @@ class DeleteHistoryRepositoryTest {
     @DisplayName("삭제 이력을 저장할 수 있다")
     @Test
     void save() {
-        DeleteHistory result = deleteHistoryRepository.save(DH1);
+        DeleteHistory actual = deleteHistoryRepository.save(DH1);
 
         assertAll(
-                () -> assertThat(result.getId()).isNotNull(),
-                () -> assertThat(result.getContentId()).isEqualTo(DH1.getContentId()),
-                () -> assertThat(result.getDeletedById()).isEqualTo(DH1.getDeletedById()),
-                () -> assertThat(result.getCreateDate()).isEqualTo(DH1.getCreateDate())
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getContentId()).isEqualTo(DH1.getContentId()),
+                () -> assertThat(actual.getDeletedBy()).isEqualTo(DH1.getDeletedBy()),
+                () -> assertThat(actual.getCreateDate()).isEqualTo(DH1.getCreateDate())
         );
     }
 }

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -5,49 +5,57 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import qna.domain.Question;
+import qna.domain.User;
+import qna.fixture.TestQuestionFactory;
+import qna.fixture.TestUserFactory;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static qna.domain.QuestionTest.Q1;
-import static qna.domain.QuestionTest.Q2;
 
 @DataJpaTest
 class QuestionRepositoryTest {
     @Autowired
     private QuestionRepository questionRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @DisplayName("질문을 저장할 수 있다")
     @Test
     void save() {
-        Question actual = questionRepository.save(Q1);
+        User writer = userRepository.save(TestUserFactory.create("서정국"));
+        Question expect = TestQuestionFactory.create(writer);
+
+        Question result = questionRepository.save(expect);
 
         assertAll(
-                () -> assertThat(actual.getId()).isNotNull(),
-                () -> assertThat(actual.isDeleted()).isEqualTo(Q1.isDeleted()),
-                () -> assertThat(actual.getWriter()).isEqualTo(Q1.getWriter()),
-                () -> assertThat(actual.getContents()).isEqualTo(Q1.getContents()),
-                () -> assertThat(actual.getTitle()).isEqualTo(Q1.getTitle())
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.isDeleted()).isEqualTo(expect.isDeleted()),
+                () -> assertThat(result.getWriter()).isEqualTo(expect.getWriter()),
+                () -> assertThat(result.getContents()).isEqualTo(expect.getContents()),
+                () -> assertThat(result.getTitle()).isEqualTo(expect.getTitle())
         );
     }
 
     @DisplayName("전체 질문을 조회할 수 있다")
     @Test
     void findAll() {
-        questionRepository.save(Q1);
-        questionRepository.save(Q2);
+        User writer = userRepository.save(TestUserFactory.create("서정국"));
+        Question question1 = questionRepository.save(TestQuestionFactory.create(writer));
+        Question question2 = questionRepository.save(TestQuestionFactory.create(writer));
 
         List<Question> results = questionRepository.findByDeletedFalse();
-        assertThat(results).contains(Q1, Q2);
+        assertThat(results).contains(question1, question2);
     }
 
     @DisplayName("삭제된 질문은 findByDeletedFalse 함수로 검색되지 않는다")
     @Test
     void deletedFindAll() {
-        Question question = questionRepository.save(Q2);
-
+        User writer = userRepository.save(TestUserFactory.create("서정국"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
         question.setDeleted(true);
 
         assertThat(questionRepository.findByDeletedFalse()).hasSize(0);
@@ -56,17 +64,19 @@ class QuestionRepositoryTest {
     @DisplayName("id로 조회할 수 있다")
     @Test
     void findById() {
-        Question actual = questionRepository.save(Q1);
+        User writer = userRepository.save(TestUserFactory.create("서정국"));
+        Question expect = questionRepository.save(TestQuestionFactory.create(writer));
 
-        Question result = questionRepository.findByIdAndDeletedFalse(actual.getId()).get();
+        Question result = questionRepository.findByIdAndDeletedFalse(expect.getId()).get();
 
-        assertThat(actual == result).isTrue();
+        assertThat(expect == result).isTrue();
     }
 
     @DisplayName("삭제된 질문은 findByIdAndDeletedFalse 함수로 조회할 수 없다")
     @Test
     void findDeletedById() {
-        Question question = questionRepository.save(Q2);
+        User writer = userRepository.save(TestUserFactory.create("서정국"));
+        Question question = questionRepository.save(TestQuestionFactory.create(writer));
         question.setDeleted(true);
 
         Optional<Question> result = questionRepository.findByIdAndDeletedFalse(question.getId());

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 class QuestionRepositoryTest {
     @Autowired
     private QuestionRepository questionRepository;

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
 class QuestionRepositoryTest {
@@ -69,7 +70,7 @@ class QuestionRepositoryTest {
 
         Question result = questionRepository.findByIdAndDeletedFalse(expect.getId()).get();
 
-        assertThat(expect == result).isTrue();
+        assertEquals(expect, result);
     }
 
     @DisplayName("삭제된 질문은 findByIdAndDeletedFalse 함수로 조회할 수 없다")

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -22,14 +22,14 @@ class QuestionRepositoryTest {
     @DisplayName("질문을 저장할 수 있다")
     @Test
     void save() {
-        Question result = questionRepository.save(Q1);
+        Question actual = questionRepository.save(Q1);
 
         assertAll(
-                () -> assertThat(result.getId()).isNotNull(),
-                () -> assertThat(result.isDeleted()).isEqualTo(Q1.isDeleted()),
-                () -> assertThat(result.getWriterId()).isEqualTo(Q1.getWriterId()),
-                () -> assertThat(result.getContents()).isEqualTo(Q1.getContents()),
-                () -> assertThat(result.getTitle()).isEqualTo(Q1.getTitle())
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.isDeleted()).isEqualTo(Q1.isDeleted()),
+                () -> assertThat(actual.getWriter()).isEqualTo(Q1.getWriter()),
+                () -> assertThat(actual.getContents()).isEqualTo(Q1.getContents()),
+                () -> assertThat(actual.getTitle()).isEqualTo(Q1.getTitle())
         );
     }
 
@@ -56,11 +56,11 @@ class QuestionRepositoryTest {
     @DisplayName("id로 조회할 수 있다")
     @Test
     void findById() {
-        Question expect = questionRepository.save(Q1);
+        Question actual = questionRepository.save(Q1);
 
-        Question result = questionRepository.findByIdAndDeletedFalse(expect.getId()).get();
+        Question result = questionRepository.findByIdAndDeletedFalse(actual.getId()).get();
 
-        assertThat(expect == result).isTrue();
+        assertThat(actual == result).isTrue();
     }
 
     @DisplayName("삭제된 질문은 findByIdAndDeletedFalse 함수로 조회할 수 없다")

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import qna.domain.User;
+import qna.fixture.TestUserFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static qna.domain.UserTest.JAVAJIGI;
 
 @DataJpaTest
 class UserRepositoryTest {
@@ -18,21 +18,22 @@ class UserRepositoryTest {
     @DisplayName("사용자를 저장할 수 있다")
     @Test
     void save() {
-        User result = userRepository.save(JAVAJIGI);
+        User expect = TestUserFactory.create("서정국");
+        User result = userRepository.save(expect);
 
         assertAll(
                 () -> assertThat(result.getId()).isNotNull(),
-                () -> assertThat(result.getUserId()).isEqualTo(JAVAJIGI.getUserId()),
-                () -> assertThat(result.getName()).isEqualTo(JAVAJIGI.getName()),
-                () -> assertThat(result.getPassword()).isEqualTo(JAVAJIGI.getPassword()),
-                () -> assertThat(result.getEmail()).isEqualTo(JAVAJIGI.getEmail())
+                () -> assertThat(result.getUserId()).isEqualTo(expect.getUserId()),
+                () -> assertThat(result.getName()).isEqualTo(expect.getName()),
+                () -> assertThat(result.getPassword()).isEqualTo(expect.getPassword()),
+                () -> assertThat(result.getEmail()).isEqualTo(expect.getEmail())
         );
     }
 
     @DisplayName("사용자 계정으로 조회할 수 있다")
     @Test
     void findByUserId() {
-        User expect = userRepository.save(JAVAJIGI);
+        User expect = userRepository.save(TestUserFactory.create("서정국"));
 
         User result = userRepository.findByUserId(expect.getUserId()).get();
 

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -9,6 +9,7 @@ import qna.fixture.TestUserFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
 class UserRepositoryTest {
@@ -37,6 +38,6 @@ class UserRepositoryTest {
 
         User result = userRepository.findByUserId(expect.getUserId()).get();
 
-        assertThat(expect == result).isTrue();
+        assertEquals(expect, result);
     }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -91,8 +91,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
안녕하세요 원철님.

지난번 피드백 주신 두가지 사항에 대해 전달드립니다.

**피드백 1: 프로퍼티 옵션**
```
spring.jpa.show-sql=true
spring.jpa.properties.hibernate.format_sql=true
```
주신 링크를 통해 `show-sql` 옵션을 `logging.level.org.hibernate.SQL=DEBUG` 옵션으로 수정했습니다.
`spring.jpa.properties.hibernate.format_sql=true` 옵션은 쿼리를 보는 가독성이 너무 달라져서 그대로 유지했습니다.

**피드백 2: 테스트 코드 비교 방식**
  주신 의견은 `assertThat(expect == result).isTrue();` 방식 보다는  `assertThat(expect).isEqualTo(result)` 방식은 어떤지 피드백을 주셨는데요. 개인적으로 팀 컨벤이션이나 취향차이로 갈릴 것 이라 생각했습니다. 그러다가 `assertEquals` 메소드가 있는걸 알게 됐고 이게 더 심플하다는 생각이 들어  `assertEquals(expect, result)` 방식으로 변경했습니다. 