### PR TITLE
2단계 - 연관 관계 매핑 과제 PR 요청 드립니다!

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -10,3 +10,10 @@
   - [X] user entity, repository 클래스 작성
     - [X] user entity의 user_id 컬럼 UniqueConstraint 지정
 - H2 데이터베이스 사용
+
+## 2단계 요구사항
+- [X] 엔티티간 연관관계 매핑
+  - [X] Answer - ManyToOne - Question 연관관계 매핑
+  - [X] Answer - ManyToOne - User 연관관계 매핑
+  - [X] DeleteHistory - ManyToOne - User 연관관계 매핑
+  - [X] Question - ManyToOne - User 연관관계 매핑

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -2,10 +2,13 @@ package qna.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -21,8 +24,9 @@ public class Answer extends DateEntity {
     @Column(nullable = true)
     private Long writerId;
 
-    @Column(nullable = true)
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "question_id")
+    private Question question;
 
     @Lob
     @Column(nullable = true)
@@ -49,7 +53,8 @@ public class Answer extends DateEntity {
         }
 
         this.writerId = writer.getId();
-        this.questionId = question.getId();
+        question.addAnswer(this);
+        this.question = question;
         this.contents = contents;
     }
 
@@ -65,16 +70,12 @@ public class Answer extends DateEntity {
         return this.writerId.equals(writer.getId());
     }
 
-    public void toQuestion(Question question) {
-        this.questionId = question.getId();
-    }
-
     public Long getWriterId() {
         return writerId;
     }
 
-    public Long getQuestionId() {
-        return questionId;
+    public Question getQuestion() {
+        return question;
     }
 
     public String getContents() {
@@ -94,7 +95,7 @@ public class Answer extends DateEntity {
         return "Answer{" +
                 "id=" + id +
                 ", writerId=" + writerId +
-                ", questionId=" + questionId +
+                ", questionId=" + question.getId() +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -64,12 +64,8 @@ public class Answer extends DateEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public boolean isOwner(User writer) {
-        return user.getId().equals(writer.getId());
+        return user.equals(writer);
     }
 
     public User getWriter() {
@@ -96,7 +92,7 @@ public class Answer extends DateEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + user.getId() +
+                ", writerId=" + user.getUserId() +
                 ", questionId=" + question.getId() +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -54,7 +54,7 @@ public class Answer extends DateEntity {
             throw new NotFoundException();
         }
 
-        this.user = writer;
+        this.writer = writer;
         question.addAnswer(this);
         this.question = question;
         this.contents = contents;
@@ -65,11 +65,11 @@ public class Answer extends DateEntity {
     }
 
     public boolean isOwner(User writer) {
-        return user.equals(writer);
+        return this.writer.equals(writer);
     }
 
     public User getWriter() {
-        return user;
+        return writer;
     }
 
     public Question getQuestion() {
@@ -92,7 +92,7 @@ public class Answer extends DateEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + user.getUserId() +
+                ", writerId=" + writer.getUserId() +
                 ", questionId=" + question.getId() +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -22,11 +22,11 @@ public class Answer extends DateEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
-    private User user;
+    private User writer;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -21,8 +21,9 @@ public class Answer extends DateEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = true)
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "writer_id")
+    private User user;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "question_id")
@@ -52,7 +53,7 @@ public class Answer extends DateEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
+        this.user = writer;
         question.addAnswer(this);
         this.question = question;
         this.contents = contents;
@@ -67,11 +68,11 @@ public class Answer extends DateEntity {
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return user.getId().equals(writer.getId());
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return user;
     }
 
     public Question getQuestion() {
@@ -94,7 +95,7 @@ public class Answer extends DateEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
+                ", writerId=" + user.getId() +
                 ", questionId=" + question.getId() +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -3,6 +3,7 @@ package qna.domain;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -22,11 +23,11 @@ public class Answer extends DateEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "writer_id")
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_answer_writer"))
     private User user;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "question_id")
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
 
     @Lob

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -28,7 +29,7 @@ public class DeleteHistory {
     private Long contentId;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "deleted_by_id")
+    @JoinColumn(name = "deleted_by_id", foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
     private User deleteUser;
 
     @Column(nullable = true, updatable = false)

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -74,7 +74,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deleteUser.getId() +
+                ", deletedById=" + deleteUser.getUserId() +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -6,9 +6,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class DeleteHistory {
@@ -24,18 +27,19 @@ public class DeleteHistory {
     @Column(nullable = true)
     private Long contentId;
 
-    @Column(nullable = true)
-    private Long deletedById;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "deleted_by_id")
+    private User deleteUser;
 
     @Column(nullable = true, updatable = false)
     private LocalDateTime createDate = LocalDateTime.now();
 
     protected DeleteHistory() { }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deleteUser, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deleteUser = deleteUser;
         this.createDate = createDate;
     }
 
@@ -55,12 +59,12 @@ public class DeleteHistory {
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&
                 Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+                Objects.equals(deleteUser, that.deleteUser);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deleteUser);
     }
 
     @Override
@@ -69,7 +73,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deletedById=" + deleteUser.getId() +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -64,7 +64,7 @@ public class Question extends DateEntity {
     }
 
     public boolean isOwner(User writer) {
-        return this.user.getId().equals(writer.getId());
+        return this.user.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -101,7 +101,7 @@ public class Question extends DateEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + user.getId() +
+                ", writerId=" + user.getUserId() +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -2,17 +2,7 @@ package qna.domain;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 
 @Entity
 public class Question extends DateEntity {
@@ -32,7 +22,7 @@ public class Question extends DateEntity {
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
-    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private final List<Answer> answers = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -22,7 +22,7 @@ public class Question extends DateEntity {
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
-    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, orphanRemoval = true)
     private final List<Answer> answers = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,15 @@
 package qna.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.OneToMany;
 
 @Entity
 public class Question extends DateEntity {
@@ -23,6 +27,9 @@ public class Question extends DateEntity {
 
     @Column(nullable = true)
     private Long writerId;
+
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    private final List<Answer> answers = new ArrayList<>();
 
     @Column(nullable = false)
     private boolean deleted = false;
@@ -57,7 +64,7 @@ public class Question extends DateEntity {
     }
 
     public void addAnswer(Answer answer) {
-        answer.toQuestion(this);
+        answers.add(answer);
     }
 
     public String getTitle() {
@@ -70,6 +77,10 @@ public class Question extends DateEntity {
 
     public Long getWriterId() {
         return writerId;
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -8,7 +8,9 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 @Entity
@@ -25,8 +27,9 @@ public class Question extends DateEntity {
     @Column(nullable = true)
     private String contents;
 
-    @Column(nullable = true)
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "writer_id")
+    private User user;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private final List<Answer> answers = new ArrayList<>();
@@ -55,12 +58,12 @@ public class Question extends DateEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.user = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.user.getId().equals(writer.getId());
     }
 
     public void addAnswer(Answer answer) {
@@ -76,7 +79,7 @@ public class Question extends DateEntity {
     }
 
     public Long getWriterId() {
-        return writerId;
+        return user.getId();
     }
 
     public List<Answer> getAnswers() {
@@ -97,7 +100,7 @@ public class Question extends DateEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writerId=" + user.getId() +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -30,7 +30,7 @@ public class Question extends DateEntity {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
-    private User user;
+    private User writer;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private final List<Answer> answers = new ArrayList<>();
@@ -59,12 +59,12 @@ public class Question extends DateEntity {
     }
 
     public Question writeBy(User writer) {
-        this.user = writer;
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.user.equals(writer);
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -80,7 +80,7 @@ public class Question extends DateEntity {
     }
 
     public User getWriter() {
-        return user;
+        return writer;
     }
 
     public List<Answer> getAnswers() {
@@ -101,7 +101,7 @@ public class Question extends DateEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + user.getUserId() +
+                ", writerId=" + writer.getUserId() +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -28,7 +29,7 @@ public class Question extends DateEntity {
     private String contents;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "writer_id")
+    @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User user;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -78,8 +78,8 @@ public class Question extends DateEntity {
         return contents;
     }
 
-    public Long getWriterId() {
-        return user.getId();
+    public User getWriter() {
+        return user;
     }
 
     public List<Answer> getAnswers() {

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,10 +1,14 @@
 package qna.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import qna.UnAuthorizedException;
 
 import java.util.Objects;
@@ -28,6 +32,12 @@ public class User extends DateEntity {
 
     @Column(length = 50, nullable = true)
     private String email;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private final List<Answer> answers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private final List<Question> questions = new ArrayList<>();
 
     protected User() { }
 

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -91,10 +91,6 @@ public class User extends DateEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getUserId() {
         return userId;
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -36,7 +36,7 @@ public class User extends DateEntity {
     @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
     private final List<Answer> answers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
     private final List<Question> questions = new ArrayList<>();
 
     protected User() { }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -128,4 +128,21 @@ public class User extends DateEntity {
             return true;
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -33,7 +33,7 @@ public class User extends DateEntity {
     @Column(length = 50, nullable = true)
     private String email;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
     private final List<Answer> answers = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -33,12 +33,6 @@ public class User extends DateEntity {
     @Column(length = 50, nullable = true)
     private String email;
 
-    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
-    private final List<Answer> answers = new ArrayList<>();
-
-    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
-    private final List<Question> questions = new ArrayList<>();
-
     protected User() { }
 
     public User(String userId, String password, String name, String email) {

--- a/src/main/java/qna/repository/AnswerRepository.java
+++ b/src/main/java/qna/repository/AnswerRepository.java
@@ -2,12 +2,10 @@ package qna.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 import qna.domain.Answer;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
 
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/qna/repository/AnswerRepository.java
+++ b/src/main/java/qna/repository/AnswerRepository.java
@@ -2,10 +2,11 @@ package qna.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import qna.domain.Answer;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-
+    List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -41,7 +41,7 @@ public class QnaService {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        List<Answer> answers = question.getAnswers();
+        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
         for (Answer answer : answers) {
             if (!answer.isOwner(loginUser)) {
                 throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -53,7 +53,7 @@ public class QnaService {
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -18,9 +18,9 @@ import qna.repository.QuestionRepository;
 public class QnaService {
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
-    private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
-    private DeleteHistoryService deleteHistoryService;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final DeleteHistoryService deleteHistoryService;
 
     public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
@@ -41,7 +41,7 @@ public class QnaService {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
+        List<Answer> answers = question.getAnswers();
         for (Answer answer : answers) {
             if (!answer.isOwner(loginUser)) {
                 throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -50,10 +50,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,23 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Test
+    @DisplayName("Answer 등록시 Question에 등록된 Answer 조회 테스트")
+    public void getAnswers() {
+        Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        assertThat(Q1.getAnswers().size()).isEqualTo(1);
+        assertThat(Q1.getAnswers()).containsExactly(A1);
+
+        Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+        assertThat(Q1.getAnswers().size()).isEqualTo(2);
+        assertThat(Q1.getAnswers()).containsExactly(A1, A2);
+    }
 }

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -85,6 +85,16 @@ public class AnswerRepositoryTest {
         assertThat(optional).isEmpty();
     }
 
+    @Test
+    @DisplayName("Question 제거시 연관관계에 있는 Answer 모두 제거")
+    public void deleteQuestionWithAnswers() {
+        saveAndRefetch(answer1);
+        saveAndRefetch(answer2);
+        Question question = answer1.getQuestion();
+        questionRepository.delete(question);
+        assertThat(answerRepository.findAll()).isEmpty();
+    }
+
     private Answer saveAndRefetch(Answer answer) {
         Answer saved = saveAndClear(answer);
         return answerRepository.findById(saved.getId())

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -3,9 +3,8 @@ package qna.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,18 +19,22 @@ import qna.domain.User;
 public class AnswerRepositoryTest {
 
     @Autowired
-    private AnswerRepository repository;
+    private AnswerRepository answerRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
 
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static Answer answer1;
-    private static Answer answer2;
+    private Answer answer1;
+    private Answer answer2;
 
-    @BeforeAll
-    public static void init() {
+    @BeforeEach
+    public void init() {
         User user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
         Question question = new Question("title1", "contents1").writeBy(user);
+        questionRepository.save(question);
         answer1 = new Answer(user, question, "Answers Contents1");
         answer2 = new Answer(user, question, "Answers Contents2");
     }
@@ -43,7 +46,7 @@ public class AnswerRepositoryTest {
         assertAll(
                 () -> assertThat(saved.getId()).isNotNull(),
                 () -> assertThat(saved.getContents()).isEqualTo(answer1.getContents()),
-                () -> assertThat(saved.getQuestionId()).isEqualTo(answer1.getQuestionId()),
+                () -> assertThat(saved.getQuestion().getId()).isEqualTo(answer1.getQuestion().getId()),
                 () -> assertThat(saved.getWriterId()).isEqualTo(answer1.getWriterId())
         );
     }
@@ -52,7 +55,7 @@ public class AnswerRepositoryTest {
     @DisplayName("개별 조회 by id")
     public void findById() {
         Answer saved = saveAndClear(answer1);
-        Optional<Answer> optional = repository.findById(saved.getId());
+        Optional<Answer> optional = answerRepository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         Answer fetched = optional.get();
         assertThat(fetched.getId()).isEqualTo(saved.getId());
@@ -62,39 +65,29 @@ public class AnswerRepositoryTest {
     @DisplayName("개별 조회 by id, deleted(false)")
     public void findByIdAndDeletedFalse() {
         Answer saved = saveAndClear(answer1);
-        Optional<Answer> optional = repository.findByIdAndDeletedFalse(saved.getId());
+        Optional<Answer> optional = answerRepository.findByIdAndDeletedFalse(saved.getId());
         assertThat(optional).isNotEmpty();
         Answer fetched = optional.get();
         assertThat(fetched.getId()).isEqualTo(saved.getId());
     }
 
     @Test
-    @DisplayName("목록 조회 by questionId, deleted(false)")
-    public void findByQuestionIdAndDeletedFalse() {
-        saveAndClear(answer1);
-        saveAndClear(answer2);
-        List<Answer> actives = repository.findByQuestionIdAndDeletedFalse(answer1.getQuestionId());
-        assertThat(actives).isNotEmpty();
-        assertThat(actives.size()).isEqualTo(2);
-    }
-
-    @Test
     @DisplayName("제거")
     public void delete() {
         Answer saved = saveAndRefetch(answer1);
-        repository.delete(saved);
-        Optional<Answer> optional = repository.findById(saved.getId());
+        answerRepository.delete(saved);
+        Optional<Answer> optional = answerRepository.findById(saved.getId());
         assertThat(optional).isEmpty();
     }
 
     private Answer saveAndRefetch(Answer answer) {
         Answer saved = saveAndClear(answer);
-        return repository.findById(saved.getId())
+        return answerRepository.findById(saved.getId())
                 .orElseThrow(() -> new NullPointerException("Answer not saved!"));
     }
 
     private Answer saveAndClear(Answer answer) {
-        Answer saved = repository.save(answer);
+        Answer saved = answerRepository.save(answer);
         testEntityManager.clear();
         return saved;
     }

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -52,7 +52,7 @@ public class AnswerRepositoryTest {
                 () -> assertThat(saved.getId()).isNotNull(),
                 () -> assertThat(saved.getContents()).isEqualTo(answer1.getContents()),
                 () -> assertThat(saved.getQuestion().getId()).isEqualTo(answer1.getQuestion().getId()),
-                () -> assertThat(saved.getWriter().getId()).isEqualTo(answer1.getWriter().getId())
+                () -> assertThat(saved.getWriter()).isEqualTo(answer1.getWriter())
         );
     }
 

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -25,14 +25,19 @@ public class AnswerRepositoryTest {
     private QuestionRepository questionRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TestEntityManager testEntityManager;
 
+    private User user;
     private Answer answer1;
     private Answer answer2;
 
     @BeforeEach
     public void init() {
-        User user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
+        user = new User("taewon", "password", "name", "htw1800@naver.com");
+        userRepository.save(user);
         Question question = new Question("title1", "contents1").writeBy(user);
         questionRepository.save(question);
         answer1 = new Answer(user, question, "Answers Contents1");
@@ -47,7 +52,7 @@ public class AnswerRepositoryTest {
                 () -> assertThat(saved.getId()).isNotNull(),
                 () -> assertThat(saved.getContents()).isEqualTo(answer1.getContents()),
                 () -> assertThat(saved.getQuestion().getId()).isEqualTo(answer1.getQuestion().getId()),
-                () -> assertThat(saved.getWriterId()).isEqualTo(answer1.getWriterId())
+                () -> assertThat(saved.getWriter().getId()).isEqualTo(answer1.getWriter().getId())
         );
     }
 

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -3,6 +3,7 @@ package qna.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +75,16 @@ public class AnswerRepositoryTest {
         assertThat(optional).isNotEmpty();
         Answer fetched = optional.get();
         assertThat(fetched.getId()).isEqualTo(saved.getId());
+    }
+
+    @Test
+    @DisplayName("목록 조회 by questionId, deleted(false)")
+    public void findByQuestionIdAndDeletedFalse() {
+        saveAndClear(answer1);
+        saveAndClear(answer2);
+        List<Answer> actives = answerRepository.findByQuestionIdAndDeletedFalse(answer1.getQuestion().getId());
+        assertThat(actives).isNotEmpty();
+        assertThat(actives.size()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import qna.domain.Answer;
 import qna.domain.Question;
-import qna.domain.QuestionTest;
 import qna.domain.User;
 
 @DataJpaTest
@@ -26,33 +25,33 @@ public class AnswerRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static Answer A1;
-    private static Answer A2;
+    private static Answer answer1;
+    private static Answer answer2;
 
     @BeforeAll
     public static void init() {
         User user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
         Question question = new Question("title1", "contents1").writeBy(user);
-        A1 = new Answer(user, question, "Answers Contents1");
-        A2 = new Answer(user, question, "Answers Contents2");
+        answer1 = new Answer(user, question, "Answers Contents1");
+        answer2 = new Answer(user, question, "Answers Contents2");
     }
 
     @Test
     @DisplayName("저장")
     public void save() {
-        Answer saved = saveAndRefetch(A1);
+        Answer saved = saveAndRefetch(answer1);
         assertAll(
                 () -> assertThat(saved.getId()).isNotNull(),
-                () -> assertThat(saved.getContents()).isEqualTo(A1.getContents()),
-                () -> assertThat(saved.getQuestionId()).isEqualTo(A1.getQuestionId()),
-                () -> assertThat(saved.getWriterId()).isEqualTo(A1.getWriterId())
+                () -> assertThat(saved.getContents()).isEqualTo(answer1.getContents()),
+                () -> assertThat(saved.getQuestionId()).isEqualTo(answer1.getQuestionId()),
+                () -> assertThat(saved.getWriterId()).isEqualTo(answer1.getWriterId())
         );
     }
 
     @Test
     @DisplayName("개별 조회 by id")
     public void findById() {
-        Answer saved = saveAndClear(A1);
+        Answer saved = saveAndClear(answer1);
         Optional<Answer> optional = repository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         Answer fetched = optional.get();
@@ -62,7 +61,7 @@ public class AnswerRepositoryTest {
     @Test
     @DisplayName("개별 조회 by id, deleted(false)")
     public void findByIdAndDeletedFalse() {
-        Answer saved = saveAndClear(A1);
+        Answer saved = saveAndClear(answer1);
         Optional<Answer> optional = repository.findByIdAndDeletedFalse(saved.getId());
         assertThat(optional).isNotEmpty();
         Answer fetched = optional.get();
@@ -72,9 +71,9 @@ public class AnswerRepositoryTest {
     @Test
     @DisplayName("목록 조회 by questionId, deleted(false)")
     public void findByQuestionIdAndDeletedFalse() {
-        saveAndClear(A1);
-        saveAndClear(A2);
-        List<Answer> actives = repository.findByQuestionIdAndDeletedFalse(A1.getQuestionId());
+        saveAndClear(answer1);
+        saveAndClear(answer2);
+        List<Answer> actives = repository.findByQuestionIdAndDeletedFalse(answer1.getQuestionId());
         assertThat(actives).isNotEmpty();
         assertThat(actives.size()).isEqualTo(2);
     }
@@ -82,7 +81,7 @@ public class AnswerRepositoryTest {
     @Test
     @DisplayName("제거")
     public void delete() {
-        Answer saved = saveAndRefetch(A1);
+        Answer saved = saveAndRefetch(answer1);
         repository.delete(saved);
         Optional<Answer> optional = repository.findById(saved.getId());
         assertThat(optional).isEmpty();

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,22 +12,29 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import qna.domain.ContentType;
 import qna.domain.DeleteHistory;
+import qna.domain.User;
 
 @DataJpaTest
 @DisplayName("DeleteHistory")
 public class DeleteHistoryRepositoryTest {
 
     @Autowired
-    private DeleteHistoryRepository repository;
+    private DeleteHistoryRepository deleteHistoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static DeleteHistory deleteHistory;
+    private User user;
+    private DeleteHistory deleteHistory;
 
-    @BeforeAll
-    public static void init() {
-        deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+    @BeforeEach
+    public void init() {
+        user = new User("taewon", "password", "name", "htw1800@naver.com");
+        userRepository.save(user);
+        deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, user, LocalDateTime.now());
     }
 
     @Test
@@ -41,7 +48,7 @@ public class DeleteHistoryRepositoryTest {
     @DisplayName("개별 조회 by id")
     public void findById() {
         DeleteHistory saved = saveAndClear(deleteHistory);
-        Optional<DeleteHistory> optional = repository.findById(saved.getId());
+        Optional<DeleteHistory> optional = deleteHistoryRepository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         DeleteHistory fetched = optional.get();
         assertThat(fetched.getId()).isEqualTo(saved.getId());
@@ -51,19 +58,19 @@ public class DeleteHistoryRepositoryTest {
     @DisplayName("제거")
     public void delete() {
         DeleteHistory saved = saveAndRefetch(deleteHistory);
-        repository.delete(saved);
-        Optional<DeleteHistory> optional = repository.findById(saved.getId());
+        deleteHistoryRepository.delete(saved);
+        Optional<DeleteHistory> optional = deleteHistoryRepository.findById(saved.getId());
         assertThat(optional).isEmpty();
     }
 
     private DeleteHistory saveAndRefetch(DeleteHistory deleteHistory) {
         DeleteHistory saved = saveAndClear(deleteHistory);
-        return repository.findById(saved.getId())
+        return deleteHistoryRepository.findById(saved.getId())
                 .orElseThrow(() -> new NullPointerException("DeleteHistory not saved!"));
     }
 
     private DeleteHistory saveAndClear(DeleteHistory deleteHistory) {
-        DeleteHistory saved = repository.save(deleteHistory);
+        DeleteHistory saved = deleteHistoryRepository.save(deleteHistory);
         testEntityManager.clear();
         return saved;
     }

--- a/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/repository/DeleteHistoryRepositoryTest.java
@@ -23,24 +23,24 @@ public class DeleteHistoryRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static DeleteHistory D1;
+    private static DeleteHistory deleteHistory;
 
     @BeforeAll
     public static void init() {
-        D1 = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+        deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
     }
 
     @Test
     @DisplayName("저장")
     public void save() {
-        DeleteHistory saved = saveAndRefetch(D1);
+        DeleteHistory saved = saveAndRefetch(deleteHistory);
         assertThat(saved.getId()).isNotNull();
     }
 
     @Test
     @DisplayName("개별 조회 by id")
     public void findById() {
-        DeleteHistory saved = saveAndClear(D1);
+        DeleteHistory saved = saveAndClear(deleteHistory);
         Optional<DeleteHistory> optional = repository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         DeleteHistory fetched = optional.get();
@@ -50,7 +50,7 @@ public class DeleteHistoryRepositoryTest {
     @Test
     @DisplayName("제거")
     public void delete() {
-        DeleteHistory saved = saveAndRefetch(D1);
+        DeleteHistory saved = saveAndRefetch(deleteHistory);
         repository.delete(saved);
         Optional<DeleteHistory> optional = repository.findById(saved.getId());
         assertThat(optional).isEmpty();

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -25,30 +25,30 @@ public class QuestionRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static Question Q1;
+    private static Question question;
 
     @BeforeAll
     public static void init() {
         User user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
-        Q1 = new Question("title1", "contents1").writeBy(user);
+        question = new Question("title1", "contents1").writeBy(user);
     }
 
     @Test
     @DisplayName("저장")
     public void save() {
-        Question saved = saveAndRefetch(Q1);
+        Question saved = saveAndRefetch(question);
         assertAll(
                 () -> assertThat(saved.getId()).isNotNull(),
-                () -> assertThat(saved.getTitle()).isEqualTo(Q1.getTitle()),
-                () -> assertThat(saved.getWriterId()).isEqualTo(Q1.getWriterId()),
-                () -> assertThat(saved.getContents()).isEqualTo(Q1.getContents())
+                () -> assertThat(saved.getTitle()).isEqualTo(question.getTitle()),
+                () -> assertThat(saved.getWriterId()).isEqualTo(question.getWriterId()),
+                () -> assertThat(saved.getContents()).isEqualTo(question.getContents())
         );
     }
 
     @Test
     @DisplayName("개별 조회 by id")
     public void findById() {
-        Question saved = saveAndClear(Q1);
+        Question saved = saveAndClear(question);
         Optional<Question> optional = repository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         Question fetched = optional.get();
@@ -58,7 +58,7 @@ public class QuestionRepositoryTest {
     @Test
     @DisplayName("개별 조회 by id, deleted(false)")
     public void findByIdAndDeletedFalse() {
-        Question saved = saveAndClear(Q1);
+        Question saved = saveAndClear(question);
         Optional<Question> optional = repository.findByIdAndDeletedFalse(saved.getId());
         assertThat(optional).isNotEmpty();
         Question fetched = optional.get();
@@ -69,7 +69,7 @@ public class QuestionRepositoryTest {
     @Test
     @DisplayName("목록 조회 by deleted(false)")
     public void findByDeletedFalse() {
-        saveAndClear(Q1);
+        saveAndClear(question);
         saveAndClear(QuestionTest.Q2);
         List<Question> actives = repository.findByDeletedFalse();
         assertThat(actives).isNotEmpty();
@@ -79,7 +79,7 @@ public class QuestionRepositoryTest {
     @Test
     @DisplayName("제거")
     public void delete() {
-        Question saved = saveAndRefetch(Q1);
+        Question saved = saveAndRefetch(question);
         repository.delete(saved);
         Optional<Question> optional = repository.findById(saved.getId());
         assertThat(optional).isEmpty();

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import qna.domain.Question;
-import qna.domain.QuestionTest;
 import qna.domain.User;
 
 @DataJpaTest
@@ -47,7 +46,7 @@ public class QuestionRepositoryTest {
         assertAll(
                 () -> assertThat(saved.getId()).isNotNull(),
                 () -> assertThat(saved.getTitle()).isEqualTo(question1.getTitle()),
-                () -> assertThat(saved.getWriterId()).isEqualTo(question1.getWriterId()),
+                () -> assertThat(saved.getWriter()).isEqualTo(question1.getWriter()),
                 () -> assertThat(saved.getContents()).isEqualTo(question1.getContents())
         );
     }

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,11 +23,11 @@ public class UserRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static User user;
+    private User user;
 
-    @BeforeAll
-    public static void init() {
-        user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
+    @BeforeEach
+    public void init() {
+        user = new User("taewon", "password", "name", "htw1800@naver.com");
     }
 
     @Test
@@ -34,7 +35,7 @@ public class UserRepositoryTest {
     public void save() {
         User saved = saveAndRefetch(user);
         assertAll(
-                () -> assertThat(saved.getId()).isNotNull(),
+                () -> assertThat(saved).isEqualTo(user),
                 () -> assertThat(saved.getUserId()).isEqualTo(user.getUserId()),
                 () -> assertThat(saved.getEmail()).isEqualTo(user.getEmail()),
                 () -> assertThat(saved.getName()).isEqualTo(user.getName()),
@@ -49,7 +50,7 @@ public class UserRepositoryTest {
         Optional<User> optional = repository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         User fetched = optional.get();
-        assertThat(fetched.getId()).isEqualTo(saved.getId());
+        assertThat(fetched).isEqualTo(saved);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class UserRepositoryTest {
         Optional<User> optional = repository.findByUserId(saved.getUserId());
         assertThat(optional).isNotEmpty();
         User fetched = optional.get();
-        assertThat(fetched.getId()).isEqualTo(saved.getId());
+        assertThat(fetched).isEqualTo(saved);
         assertThat(fetched.getUserId()).isEqualTo(saved.getUserId());
     }
 

--- a/src/test/java/qna/repository/UserRepositoryTest.java
+++ b/src/test/java/qna/repository/UserRepositoryTest.java
@@ -22,30 +22,30 @@ public class UserRepositoryTest {
     @Autowired
     private TestEntityManager testEntityManager;
 
-    private static User U1;
+    private static User user;
 
     @BeforeAll
     public static void init() {
-        U1 = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
+        user = new User(1L, "taewon", "password", "name", "htw1800@naver.com");
     }
 
     @Test
     @DisplayName("저장")
     public void save() {
-        User saved = saveAndRefetch(U1);
+        User saved = saveAndRefetch(user);
         assertAll(
                 () -> assertThat(saved.getId()).isNotNull(),
-                () -> assertThat(saved.getUserId()).isEqualTo(U1.getUserId()),
-                () -> assertThat(saved.getEmail()).isEqualTo(U1.getEmail()),
-                () -> assertThat(saved.getName()).isEqualTo(U1.getName()),
-                () -> assertThat(saved.getPassword()).isEqualTo(U1.getPassword())
+                () -> assertThat(saved.getUserId()).isEqualTo(user.getUserId()),
+                () -> assertThat(saved.getEmail()).isEqualTo(user.getEmail()),
+                () -> assertThat(saved.getName()).isEqualTo(user.getName()),
+                () -> assertThat(saved.getPassword()).isEqualTo(user.getPassword())
         );
     }
 
     @Test
     @DisplayName("개별 조회 by id")
     public void findById() {
-        User saved = saveAndClear(U1);
+        User saved = saveAndClear(user);
         Optional<User> optional = repository.findById(saved.getId());
         assertThat(optional).isNotEmpty();
         User fetched = optional.get();
@@ -55,7 +55,7 @@ public class UserRepositoryTest {
     @Test
     @DisplayName("개별 조회 by userId")
     public void findByUserId() {
-        User saved = saveAndClear(U1);
+        User saved = saveAndClear(user);
         Optional<User> optional = repository.findByUserId(saved.getUserId());
         assertThat(optional).isNotEmpty();
         User fetched = optional.get();
@@ -66,7 +66,7 @@ public class UserRepositoryTest {
     @Test
     @DisplayName("제거")
     public void delete() {
-        User saved = saveAndRefetch(U1);
+        User saved = saveAndRefetch(user);
         repository.delete(saved);
         Optional<User> optional = repository.findById(saved.getId());
         assertThat(optional).isEmpty();

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QnaServiceTest {
+
     @Mock
     private QuestionRepository questionRepository;
 
@@ -42,13 +43,11 @@ class QnaServiceTest {
     public void setUp() throws Exception {
         question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
         answer = new Answer(1L, UserTest.JAVAJIGI, question, "Answers Contents1");
-        question.addAnswer(answer);
     }
 
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -68,7 +67,6 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -79,11 +77,9 @@ class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
-        question.addAnswer(answer2);
+        Answer answer2 = new Answer(2L, UserTest.SANJIGI, question, "Answers Contents1");
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -87,8 +87,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
 import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
 
@@ -48,6 +49,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -67,6 +69,7 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -80,6 +83,7 @@ class QnaServiceTest {
         Answer answer2 = new Answer(2L, UserTest.SANJIGI, question, "Answers Contents1");
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
+        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -88,7 +88,7 @@ class QnaServiceTest {
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
                 new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter().getId(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
안녕하세요!
2단계 연관 관계 매핑 과제 수행이 완료되어 PR 드립니다!
이번 과제에서 처리한 내용들은 아래와 같습니다!

- Answer - Question 간 @ManyToOne 양방향 연관관계 매핑
  - 연관관계 매핑으로 인해 더이상 사용이 의미 없어진 answerRepository의  findByQuestionIdAndDeletedFalse 메소드 제거
- Answer - User 간 @ManyToOne 양방향 연관관계 매핑
- DeleteHistory - User 간 @ManyToOne 단방향 연관관계 매핑
  - User는 DeleteHistory를 당장 조회할 필요가 없다고 판단하여 우선 단방향으로 지정 처리
- Question - User 간 @ManyToOne 양방향 연관관계 매핑
- 각 연관관계 매핑시 FK 지정
- User의 ID(PK)를 직접적으로 access 하는 부분 모두 제거
  - User의 경우 고유한 유저임을 확인할 수 있는 userId 가 존재하기 때문에 pk 값 사용 비권장
  - User 인스턴스간 동일성을 비교할 수 있는 equal 메소드 Override 및 PK 값을 이용하여 비교 처리

감사합니다!