### PR TITLE
JPA Step3: 질문 삭제하기 리팩터링 리뷰 요청드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,62 @@ alter table question
         foreign key (writer_id)
             references user (id)
 ```
+
+## 3단계 - 질문 삭제하기 리팩터링
+
+### 기능 요구사항
+- QnA 서비스를 만들어가면서 JPA로 실제 도메인 모델을 어떻게 구성하고 객체와 테이블을 어떻게 매핑해야 하는지 알아본다.
+  - 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
+  - 로그인 사용자와 질문한 사람이 같은 경우 삭제할 수 있다.
+  - 답변이 없는 경우 삭제가 가능하다.
+  - 질문자와 답변 글의 모든 답변자 같은 경우 삭제가 가능하다.
+  - 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경한다.
+  - 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.
+  - 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.
+
+### 프로그래밍 요구사항
+- qna.service.QnaService의 deleteQuestion()는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메서드는 단위 테스트하기 어려운 코드와 단위 
+테스트 가능한 코드가 섞여 있다.
+- 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드를 분리해 단위 테스트 가능한 코드에 대해 단위 테스트를 구현한다.
+- 리팩터링을 완료한 후에도 src/test/java 디렉터리의 qna.service.QnaServiceTest의 모든 테스트가 통과해야 한다.
+
+```java
+@Transactional
+public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
+    Question question = findQuestionById(questionId);
+    if (!question.isOwner(loginUser)) {
+        throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+    }
+
+    List<Answer> answers = question.getAnswers();
+    for (Answer answer : answers) {
+        if (!answer.isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+    }
+
+    List<DeleteHistory> deleteHistories = new ArrayList<>();
+    question.setDeleted(true);
+    deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+    for (Answer answer : answers) {
+        answer.setDeleted(true);
+        deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+    }
+    deleteHistoryService.saveAll(deleteHistories);
+}
+```
+
+- 자바 코드 컨벤션을 지키면서 프로그래밍한다.
+  - 기본적으로 Google Java Style Guide을 원칙으로 한다.
+  - 단, 들여쓰기는 '2 spaces'가 아닌 '4 spaces'로 한다.
+- indent(인덴트, 들여쓰기) depth를 2를 넘지 않도록 구현한다. 1까지만 허용한다.
+- 3항 연산자를 쓰지 않는다.
+- else 예약어를 쓰지 않는다.
+- 모든 기능을 TDD로 구현해 단위 테스트가 존재해야 한다. 단, UI(System.out, System.in) 로직은 제외
+- 함수(또는 메서드)의 길이가 10라인을 넘어가지 않도록 구현한다.
+- 배열 대신 컬렉션을 사용한다.
+- 모든 원시 값과 문자열을 포장한다
+- 줄여 쓰지 않는다(축약 금지).
+- 일급 컬렉션을 쓴다.
+- 모든 엔티티를 작게 유지한다.
+- 3개 이상의 인스턴스 변수를 가진 클래스를 쓰지 않는다.

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -84,7 +84,7 @@ public class Answer extends BaseEntity {
         }
 
         setDeleted(true);
-        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+        return DeleteHistory.createAnswer(id, writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -39,7 +39,7 @@ public class Answer extends BaseEntity {
         }
 
         this.writer = writer;
-        this.question = question;
+        toQuestion(question);
         this.contents = contents;
     }
 
@@ -51,6 +51,7 @@ public class Answer extends BaseEntity {
 
     public void toQuestion(Question question) {
         this.question = question;
+        question.addAnswer(this);
     }
 
     public Long getId() {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -45,8 +45,8 @@ public class Answer extends BaseEntity {
 
     protected Answer() {}
 
-    public boolean isOwner(User writer) {
-        return this.writer.equals(writer);
+    public boolean isNotOwner(User writer) {
+        return !this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -79,12 +79,16 @@ public class Answer extends BaseEntity {
     }
 
     public DeleteHistory delete(User loginUser) throws CannotDeleteException {
-        if (!isOwner(loginUser)) {
-            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-        }
+        validateDeleteAuthority(loginUser);
 
         setDeleted(true);
         return DeleteHistory.createAnswer(id, writer, LocalDateTime.now());
+    }
+
+    private void validateDeleteAuthority(User loginUser) throws CannotDeleteException {
+        if (isNotOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -74,14 +74,13 @@ public class Answer extends BaseEntity {
         return deleted;
     }
 
-    public void setDeleted(boolean deleted) {
-        this.deleted = deleted;
+    public void softDelete() {
+        this.deleted = true;
     }
 
     public DeleteHistory delete(User loginUser) throws CannotDeleteException {
         validateDeleteAuthority(loginUser);
-
-        setDeleted(true);
+        softDelete();
         return DeleteHistory.createAnswer(id, writer, LocalDateTime.now());
     }
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
@@ -73,6 +74,14 @@ public class Answer extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public void delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+
+        setDeleted(true);
     }
 
     @Override

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -5,6 +5,7 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -76,12 +77,13 @@ public class Answer extends BaseEntity {
         this.deleted = deleted;
     }
 
-    public void delete(User loginUser) throws CannotDeleteException {
+    public DeleteHistory delete(User loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
 
         setDeleted(true);
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,36 @@
+package qna.domain;
+
+import qna.CannotDeleteException;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+public class Answers {
+    @OneToMany(mappedBy = "question")
+    List<Answer> answers = new ArrayList<>();
+
+    protected Answers() {}
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public void add(Answer answer) {
+        this.answers.add(answer);
+    }
+
+    public boolean contains(Answer answer) {
+        return this.answers.contains(answer);
+    }
+
+    public DeleteHistories delete(User loginUser) throws CannotDeleteException {
+        DeleteHistories deleteHistories = new DeleteHistories(new ArrayList<>());
+        for (Answer answer : answers) {
+            deleteHistories.add(answer.delete(loginUser));
+        }
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Embeddable
 public class Answers {
     @OneToMany(mappedBy = "question")
-    List<Answer> answers = new ArrayList<>();
+    private List<Answer> answers = new ArrayList<>();
 
     protected Answers() {}
 

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,0 +1,35 @@
+package qna.domain;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public class DeleteHistories {
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public void add(DeleteHistory deleteHistory) {
+        this.deleteHistories.add(deleteHistory);
+    }
+
+    public List<DeleteHistory> get() {
+        return this.deleteHistories;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeleteHistories that = (DeleteHistories) o;
+        return (deleteHistories.size() == that.deleteHistories.size()) &&
+                new HashSet<>(deleteHistories).containsAll(that.deleteHistories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deleteHistories);
+    }
+}

--- a/src/main/java/qna/domain/DeleteHistories.java
+++ b/src/main/java/qna/domain/DeleteHistories.java
@@ -1,14 +1,12 @@
 package qna.domain;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 public class DeleteHistories {
     private final List<DeleteHistory> deleteHistories;
 
     public DeleteHistories(List<DeleteHistory> deleteHistories) {
-        this.deleteHistories = deleteHistories;
+        this.deleteHistories = new ArrayList<>(deleteHistories);
     }
 
     public void add(DeleteHistory deleteHistory) {
@@ -16,13 +14,17 @@ public class DeleteHistories {
     }
 
     public List<DeleteHistory> get() {
-        return this.deleteHistories;
+        return Collections.unmodifiableList(this.deleteHistories);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DeleteHistories that = (DeleteHistories) o;
         return (deleteHistories.size() == that.deleteHistories.size()) &&
                 new HashSet<>(deleteHistories).containsAll(that.deleteHistories);

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -16,11 +16,19 @@ public class DeleteHistory {
     private User deletedBy;
     private LocalDateTime createDate = LocalDateTime.now();
 
-    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
+    private DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
         this.deletedBy = deletedBy;
         this.createDate = createDate;
+    }
+
+    public static DeleteHistory createQuestion(Long contentId, User deletedBy, LocalDateTime createDate) {
+        return new DeleteHistory(ContentType.QUESTION, contentId, deletedBy, createDate);
+    }
+
+    public static DeleteHistory createAnswer(Long contentId, User deletedBy, LocalDateTime createDate) {
+        return new DeleteHistory(ContentType.ANSWER, contentId, deletedBy, createDate);
     }
 
     protected DeleteHistory() {

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -57,8 +57,12 @@ public class DeleteHistory {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DeleteHistory that = (DeleteHistory) o;
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -97,7 +97,7 @@ public class Question extends BaseEntity  {
 
     private List<DeleteHistory> getDeleteHistories() {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(0, new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        deleteHistories.add(DeleteHistory.createQuestion(id, writer, LocalDateTime.now()));
         return deleteHistories;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -3,6 +3,7 @@ package qna.domain;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 public class Question extends BaseEntity  {
@@ -69,9 +70,17 @@ public class Question extends BaseEntity  {
         this.deleted = deleted;
     }
 
-    public void delete(User loginUser) throws CannotDeleteException {
+    public void delete(User loginUser, List<Answer> answers) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        deleteAnswers(loginUser, answers);
+    }
+
+    private void deleteAnswers(User loginUser, List<Answer> answers) throws CannotDeleteException {
+        for (Answer answer : answers) {
+            answer.delete(loginUser);
         }
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -21,6 +21,9 @@ public class Question extends BaseEntity  {
     @Column(nullable = false)
     private boolean deleted = false;
 
+    @OneToMany(mappedBy = "question")
+    List<Answer> answers = new ArrayList<>();
+
     public Question(String title, String contents) {
         this(null, title, contents);
     }
@@ -45,7 +48,9 @@ public class Question extends BaseEntity  {
     }
 
     public void addAnswer(Answer answer) {
-        answer.toQuestion(this);
+        if (!this.answers.contains(answer)) {
+            this.answers.add(answer);
+        }
     }
 
     public Long getId() {
@@ -72,16 +77,16 @@ public class Question extends BaseEntity  {
         this.deleted = deleted;
     }
 
-    public List<DeleteHistory> delete(User loginUser, List<Answer> answers) throws CannotDeleteException {
+    public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
         setDeleted(true);
-        return deleteAnswers(loginUser, answers);
+        return deleteAnswers(loginUser);
     }
 
-    private List<DeleteHistory> deleteAnswers(User loginUser, List<Answer> answers) throws CannotDeleteException {
+    private List<DeleteHistory> deleteAnswers(User loginUser) throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = getDeleteHistories();
         for (Answer answer : answers) {
             deleteHistories.add(answer.delete(loginUser));

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -77,7 +77,7 @@ public class Question extends BaseEntity  {
         this.deleted = deleted;
     }
 
-    public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
+    public DeleteHistories delete(User loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
@@ -86,8 +86,8 @@ public class Question extends BaseEntity  {
         return deleteAnswers(loginUser);
     }
 
-    private List<DeleteHistory> deleteAnswers(User loginUser) throws CannotDeleteException {
-        List<DeleteHistory> deleteHistories = getDeleteHistories();
+    private DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
+        DeleteHistories deleteHistories = getDeleteHistories();
         for (Answer answer : answers) {
             deleteHistories.add(answer.delete(loginUser));
         }
@@ -95,9 +95,10 @@ public class Question extends BaseEntity  {
         return deleteHistories;
     }
 
-    private List<DeleteHistory> getDeleteHistories() {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+    private DeleteHistories getDeleteHistories() {
+        DeleteHistories deleteHistories = new DeleteHistories(new ArrayList<>());
         deleteHistories.add(DeleteHistory.createQuestion(id, writer, LocalDateTime.now()));
+
         return deleteHistories;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -73,15 +73,15 @@ public class Question extends BaseEntity  {
         return contents;
     }
 
-    public void setDeleted(boolean deleted) {
-        this.deleted = deleted;
+    public void softDelete() {
+        this.deleted = true;
     }
 
     public DeleteHistories delete(User loginUser) throws CannotDeleteException {
         validateDeleteAuthority(loginUser);
 
-        setDeleted(true);
-        return deleteAnswers(loginUser);
+        softDelete();
+        return allDeleteHistories(deleteAnswers(loginUser));
     }
 
     private void validateDeleteAuthority(User loginUser) throws CannotDeleteException {
@@ -91,8 +91,10 @@ public class Question extends BaseEntity  {
     }
 
     private DeleteHistories deleteAnswers(User loginUser) throws CannotDeleteException {
-        DeleteHistories deleteHistories = this.answers.delete(loginUser);
+        return this.answers.delete(loginUser);
+    }
 
+    private DeleteHistories allDeleteHistories(DeleteHistories deleteHistories) {
         deleteHistories.add(DeleteHistory.createQuestion(id, writer, LocalDateTime.now()));
         return deleteHistories;
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,5 +1,7 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
+
 import javax.persistence.*;
 
 @Entity
@@ -65,6 +67,12 @@ public class Question extends BaseEntity  {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public void delete(User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 public class User extends BaseEntity {
@@ -57,6 +58,19 @@ public class User extends BaseEntity {
 
     public String getEmail() {
         return email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     @Override

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -56,8 +56,12 @@ public class User extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         User user = (User) o;
         return Objects.equals(id, user.id);
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -5,8 +5,6 @@ import java.util.Objects;
 
 @Entity
 public class User extends BaseEntity {
-    public static final GuestUser GUEST_USER = new GuestUser();
-
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(length = 20, nullable = false, unique = true)
@@ -32,10 +30,6 @@ public class User extends BaseEntity {
         this.password = password;
         this.name = name;
         this.email = email;
-    }
-
-    public boolean isGuestUser() {
-        return false;
     }
 
     public Long getId() {
@@ -82,12 +76,5 @@ public class User extends BaseEntity {
                 ", name='" + name + '\'' +
                 ", email='" + email + '\'' +
                 '}';
-    }
-
-    private static class GuestUser extends User {
-        @Override
-        public boolean isGuestUser() {
-            return true;
-        }
     }
 }

--- a/src/main/java/qna/service/DeleteHistoryService.java
+++ b/src/main/java/qna/service/DeleteHistoryService.java
@@ -3,6 +3,7 @@ package qna.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import qna.domain.DeleteHistories;
 import qna.domain.DeleteHistory;
 import qna.repository.DeleteHistoryRepository;
 
@@ -17,8 +18,8 @@ public class DeleteHistoryService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveAll(List<DeleteHistory> deleteHistories) {
-        deleteHistoryRepository.saveAll(deleteHistories);
+    public void saveAll(DeleteHistories deleteHistories) {
+        deleteHistoryRepository.saveAll(deleteHistories.get());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/qna/service/DeleteHistoryService.java
+++ b/src/main/java/qna/service/DeleteHistoryService.java
@@ -7,8 +7,6 @@ import qna.domain.DeleteHistories;
 import qna.domain.DeleteHistory;
 import qna.repository.DeleteHistoryRepository;
 
-import java.util.List;
-
 @Service
 public class DeleteHistoryService {
     private DeleteHistoryRepository deleteHistoryRepository;

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -38,15 +38,7 @@ public class QnaService {
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        question.delete(loginUser, answers);
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
+        List<DeleteHistory> deleteHistories = question.delete(loginUser, answers);
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -19,12 +19,10 @@ public class QnaService {
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
     private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
     private DeleteHistoryService deleteHistoryService;
 
-    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
+    public QnaService(QuestionRepository questionRepository, DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
-        this.answerRepository = answerRepository;
         this.deleteHistoryService = deleteHistoryService;
     }
 
@@ -37,8 +35,6 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        List<DeleteHistory> deleteHistories = question.delete(loginUser, answers);
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(question.delete(loginUser));
     }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -37,14 +37,8 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        question.delete(loginUser);
-
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+        question.delete(loginUser, answers);
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -37,9 +37,7 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        question.delete(loginUser);
 
         List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
         for (Answer answer : answers) {

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -7,12 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.domain.*;
-import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 public class QnaService {

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -2,9 +2,14 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
+import qna.fixture.TestAnswerFactory;
+import qna.fixture.TestQuestionFactory;
+import qna.fixture.TestUserFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
@@ -20,5 +25,27 @@ public class AnswerTest {
     void no_question_exception_test() {
         assertThatThrownBy(() -> new Answer(UserTest.JAVAJIGI, null, "컨텐츠"))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("답변은 삭제될 수 있다")
+    @Test
+    void delete_test() throws CannotDeleteException {
+        User writer = TestUserFactory.create("서정국");
+        Question question = TestQuestionFactory.create(writer);
+        Answer answer = TestAnswerFactory.create(writer, question);
+
+        answer.delete(writer);
+
+        assertThat(answer.isDeleted()).isTrue();
+    }
+
+    @DisplayName("답변이 삭제되면 삭제이력이 반환된다")
+    @Test
+    void delete_history_test() throws CannotDeleteException {
+        User writer = TestUserFactory.create("서정국");
+        Question question = TestQuestionFactory.create(writer);
+        Answer answer = TestAnswerFactory.create(writer, question);
+
+        assertThat(answer.delete(writer)).isInstanceOf(DeleteHistory.class);
     }
 }

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,29 @@
+package qna.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.fixture.TestUserFactory;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeleteHistoryTest {
+    @DisplayName("질문에 대한 삭제이력을 만들 수 있다")
+    @Test
+    void create_question_test() {
+        User deleteBy = TestUserFactory.create("서정국");
+        DeleteHistory deleteHistory = DeleteHistory.createQuestion(1L, deleteBy, LocalDateTime.now());
+
+        assertThat(deleteHistory.getContentType()).isEqualTo(ContentType.QUESTION);
+    }
+
+    @DisplayName("답변에 대한 삭제이력을 만들 수 있다")
+    @Test
+    void create_answer_test() {
+        User deleteBy = TestUserFactory.create("서정국");
+        DeleteHistory deleteHistory = DeleteHistory.createAnswer(1L, deleteBy, LocalDateTime.now());
+
+        assertThat(deleteHistory.getContentType()).isEqualTo(ContentType.ANSWER);
+    }
+}

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,5 +1,49 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+import qna.UnAuthorizedException;
+import qna.fixture.TestAnswerFactory;
+import qna.fixture.TestQuestionFactory;
+import qna.fixture.TestUserFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
+
+    @DisplayName("질문은 삭제될 수 있다")
+    @Test
+    void delete_test() throws CannotDeleteException {
+        User writer = TestUserFactory.create("서정국");
+        Question question = TestQuestionFactory.create(writer);
+
+        question.delete(writer);
+
+        assertThat(question.isDeleted()).isTrue();
+    }
+
+    @DisplayName("질문이 삭제되면 답변도 삭제된다")
+    @Test
+    void delete_with_answer_test() throws CannotDeleteException {
+        User writer = TestUserFactory.create("서정국");
+        Question question = TestQuestionFactory.create(writer);
+        Answer answer = TestAnswerFactory.create(writer, question);
+
+        question.delete(writer);
+
+        assertThat(question.isDeleted()).isTrue();
+        assertThat(answer.isDeleted()).isTrue();
+    }
+
+    @DisplayName("질문이 삭제되면 삭제이력이 반환된다")
+    @Test
+    void delete_history_test() throws CannotDeleteException {
+        User writer = TestUserFactory.create("서정국");
+        Question question = TestQuestionFactory.create(writer);
+
+        assertThat(question.delete(writer)).isInstanceOf(DeleteHistories.class);
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -3,13 +3,11 @@ package qna.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import qna.CannotDeleteException;
-import qna.UnAuthorizedException;
 import qna.fixture.TestAnswerFactory;
 import qna.fixture.TestQuestionFactory;
 import qna.fixture.TestUserFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -1,6 +1,20 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+
+    @DisplayName("두 유저의 id(PK)가 같다면 두 유저는 동일하다")
+    @Test
+    void identity_test() {
+        User user1 = new User(1L, "서정국", "password", "name", "email");
+        User user2 = new User(1L, "서정국2", "password", "name", "email");
+
+        assertEquals(user1, user2);
+    }
 }

--- a/src/test/java/qna/fixture/TestAnswerFactory.java
+++ b/src/test/java/qna/fixture/TestAnswerFactory.java
@@ -5,6 +5,8 @@ import qna.domain.Question;
 import qna.domain.User;
 
 public class TestAnswerFactory {
+    private TestAnswerFactory() {}
+
     public static Answer create(User writer, Question question) {
         return new Answer(writer, question, "contents");
     }

--- a/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
+++ b/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
@@ -7,6 +7,8 @@ import qna.domain.User;
 import java.time.LocalDateTime;
 
 public class TestDeleteHistoryFactory {
+    private TestDeleteHistoryFactory() {}
+
     public static DeleteHistory create(User deleteBy) {
         return DeleteHistory.createQuestion(1L, deleteBy, LocalDateTime.now());
     }

--- a/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
+++ b/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 
 public class TestDeleteHistoryFactory {
     public static DeleteHistory create(User deleteBy) {
-        return new DeleteHistory(ContentType.QUESTION, 1L, deleteBy, LocalDateTime.now());
+        return DeleteHistory.createQuestion(1L, deleteBy, LocalDateTime.now());
     }
 }

--- a/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
+++ b/src/test/java/qna/fixture/TestDeleteHistoryFactory.java
@@ -1,6 +1,5 @@
 package qna.fixture;
 
-import qna.domain.ContentType;
 import qna.domain.DeleteHistory;
 import qna.domain.User;
 

--- a/src/test/java/qna/fixture/TestQuestionFactory.java
+++ b/src/test/java/qna/fixture/TestQuestionFactory.java
@@ -4,6 +4,8 @@ import qna.domain.Question;
 import qna.domain.User;
 
 public class TestQuestionFactory {
+    private TestQuestionFactory() {}
+
     public static Question create(User writer) {
         Question question = new Question("title", "contents");
         question.writeBy(writer);

--- a/src/test/java/qna/fixture/TestUserFactory.java
+++ b/src/test/java/qna/fixture/TestUserFactory.java
@@ -3,6 +3,8 @@ package qna.fixture;
 import qna.domain.User;
 
 public class TestUserFactory {
+    private TestUserFactory() {}
+
     public static User create(String name) {
         return new User(name, "password", "userId", "email");
     }

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -77,7 +77,7 @@ class AnswerRepositoryTest {
         User writer = userRepository.save(TestUserFactory.create("writer"));
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
         Answer answer = answerRepository.save(TestAnswerFactory.create(writer, question));
-        answer.setDeleted(true);
+        answer.softDelete();
 
         Optional<Answer> result = answerRepository.findByIdAndDeletedFalse(answer.getId());
 
@@ -102,7 +102,7 @@ class AnswerRepositoryTest {
         User writer = userRepository.save(TestUserFactory.create("writer"));
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
         Answer answer = answerRepository.save(TestAnswerFactory.create(writer, question));
-        answer.setDeleted(true);
+        answer.softDelete();
 
         List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(answer.getQuestion().getId());
 

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -1,6 +1,5 @@
 package qna.repository;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,6 @@ import qna.fixture.TestUserFactory;
 
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnitUtil;
-import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,9 +34,6 @@ class AnswerRepositoryTest {
 
     @Autowired
     private QuestionRepository questionRepository;
-
-    @Autowired
-    private DeleteHistoryRepository deleteHistoryRepository;
 
     @Autowired
     private EntityManagerFactory factory;

--- a/src/test/java/qna/repository/AnswerRepositoryTest.java
+++ b/src/test/java/qna/repository/AnswerRepositoryTest.java
@@ -106,7 +106,7 @@ class AnswerRepositoryTest {
 
         List<Answer> result = answerRepository.findByQuestionIdAndDeletedFalse(answer.getQuestion().getId());
 
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
     @DisplayName("답변 조회시 writer, question이 지연로딩 되는지 확인한다")

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -63,7 +63,7 @@ class QuestionRepositoryTest {
     void deletedFindAll() {
         User writer = userRepository.save(TestUserFactory.create("서정국"));
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
-        question.setDeleted(true);
+        question.softDelete();
 
         assertThat(questionRepository.findByDeletedFalse()).isEmpty();
     }
@@ -84,7 +84,7 @@ class QuestionRepositoryTest {
     void findDeletedById() {
         User writer = userRepository.save(TestUserFactory.create("서정국"));
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
-        question.setDeleted(true);
+        question.softDelete();
 
         Optional<Question> result = questionRepository.findByIdAndDeletedFalse(question.getId());
 

--- a/src/test/java/qna/repository/QuestionRepositoryTest.java
+++ b/src/test/java/qna/repository/QuestionRepositoryTest.java
@@ -65,7 +65,7 @@ class QuestionRepositoryTest {
         Question question = questionRepository.save(TestQuestionFactory.create(writer));
         question.setDeleted(true);
 
-        assertThat(questionRepository.findByDeletedFalse()).hasSize(0);
+        assertThat(questionRepository.findByDeletedFalse()).isEmpty();
     }
 
     @DisplayName("id로 조회할 수 있다")

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -85,8 +85,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
+                DeleteHistory.createQuestion(question.getId(), question.getWriter(), LocalDateTime.now()),
+                DeleteHistory.createAnswer(answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -27,9 +27,6 @@ class QnaServiceTest {
     private QuestionRepository questionRepository;
 
     @Mock
-    private AnswerRepository answerRepository;
-
-    @Mock
     private DeleteHistoryService deleteHistoryService;
 
     @InjectMocks
@@ -48,7 +45,6 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -68,7 +64,6 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -83,7 +78,6 @@ class QnaServiceTest {
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -43,7 +43,7 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_성공() throws Exception {
+    void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();
@@ -54,7 +54,7 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_다른_사람이_쓴_글() throws Exception {
+    void delete_다른_사람이_쓴_글() {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.SANJIGI, question.getId()))
@@ -62,7 +62,7 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_성공_질문자_답변자_같음() throws Exception {
+    void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -73,7 +73,7 @@ class QnaServiceTest {
     }
 
     @Test
-    public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
+    void delete_답변_중_다른_사람이_쓴_글() {
         Answer answer2 = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
         question.addAnswer(answer2);
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -88,6 +88,6 @@ class QnaServiceTest {
                 DeleteHistory.createQuestion(question.getId(), question.getWriter(), LocalDateTime.now()),
                 DeleteHistory.createAnswer(answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
-        verify(deleteHistoryService).saveAll(deleteHistories);
+        verify(deleteHistoryService).saveAll(new DeleteHistories(deleteHistories));
     }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import qna.CannotDeleteException;
 import qna.domain.*;
-import qna.repository.AnswerRepository;
 import qna.repository.QuestionRepository;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
안녕하세요 원철님
벌써 JPA 마지막 미션이네요.

리뷰에 도움이 되기 위해 핵심 작업들을 조금 설명 드리면 아래와 같습니다.
- `Question`에 `OneToMany` 관계 추가하여, 질문 조회 시 답변도 같이 조회되도록 수정  
- `DeleteHistories` 일급 컬렉션 사용, `Answers`라는 임베디드 컬럼 사용
- `DeleteHistory` 에서 질문, 답변 각각의 삭제 이력을 생성하는 정적 팩토리 메소드 사용
- 부정 조건을 피하기 위해 `isOwner` -> `isNotOwner`로 수정 (if 문에서 ! 논리 연산자가 쓰이지 않도록)
- 질문을 삭제 시 `DeleteHistories` 반환, 답변을 삭제하면 `DeleteHistory`를 반환하는 구조
- 테스트 코드에서 `hasSize(0)` -> `isEmpty()` 로 수정

그럼 리뷰 부탁드립니다 😄 