### PR TITLE
Step3 - 질문 삭제하기 리팩터링 PR요청드립니다.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,3 +134,22 @@ alter table question
   - [x] DeleteHistoryTest
 - [x] 엔티티 클래스 setId 삭제
 - [x] User 엔티티 클래스 equals 추가
+
+<br/>
+<hr/>
+
+## 3단계 - 질문 삭제하기 리팩터링
+### 프로그래밍 요구 사항
+- `qna.service.QnaService의 deleteQuestion()`는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메서드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
+- 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드를 분리해 단위 테스트 가능한 코드에 대해 단위 테스트를 구현한다.
+- 리팩터링을 완료한 후에도 `src/test/java` 디렉터리의 `qna.service.QnaServiceTest`의 모든 테스트가 통과해야 한다.
+
+### 구현 기능 목록
+- [ ] `List<Answer>`를 일급 컬렉션 `Answers`로 만든다
+- [ ] `Question`에 글 삭제 메소드 추가
+- [ ] `Answer`에 글 삭제 메소드 추가
+- [ ] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인
+- [ ] 글 삭제 시 로그인 유저와 글쓴이가 다르면 에러 발생
+- [ ] 글 삭제는 Deleted의 값이 = true 이다
+- [ ] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
+- [ ] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,7 +145,8 @@ alter table question
 - 리팩터링을 완료한 후에도 `src/test/java` 디렉터리의 `qna.service.QnaServiceTest`의 모든 테스트가 통과해야 한다.
 
 ### 구현 기능 목록
-- [ ] `List<Answer>`를 일급 컬렉션 `Answers`로 만든다
+- [x] `List<Answer>`를 일급 컬렉션 `Answers`로 만든다
+- [x] `Question`에 `List<Answer>`를 `Answers`로 대체
 - [ ] `Question`에 글 삭제 메소드 추가
 - [ ] `Answer`에 글 삭제 메소드 추가
 - [ ] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,3 +153,4 @@ alter table question
   - [x] 글 삭제의 반환 값은 `List<DeleteHistory>`
 - [x] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
 - [x] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가
+- [x] `QnaService` 리팩터링 

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,10 +147,9 @@ alter table question
 ### 구현 기능 목록
 - [x] `List<Answer>`를 일급 컬렉션 `Answers`로 만든다
 - [x] `Question`에 `List<Answer>`를 `Answers`로 대체
-- [ ] `Question`에 글 삭제 메소드 추가
-- [ ] `Answer`에 글 삭제 메소드 추가
-- [ ] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인
-- [ ] 글 삭제 시 로그인 유저와 글쓴이가 다르면 에러 발생
-- [ ] 글 삭제는 Deleted의 값이 = true 이다
+- [ ] `Question`, `Answer`에 글 삭제 메소드 추가
+  - [x] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인
+  - [x] 글 삭제 시 로그인 유저와 글쓴이가 다르면 에러 발생
+  - [ ] 글 삭제의 반환 값은 `List<DeleteHistory>`
 - [ ] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
 - [ ] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,5 +151,5 @@ alter table question
   - [x] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인
   - [x] 글 삭제 시 로그인 유저와 글쓴이가 다르면 에러 발생
   - [ ] 글 삭제의 반환 값은 `List<DeleteHistory>`
-- [ ] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
-- [ ] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가
+- [x] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
+- [x] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,9 +147,9 @@ alter table question
 ### 구현 기능 목록
 - [x] `List<Answer>`를 일급 컬렉션 `Answers`로 만든다
 - [x] `Question`에 `List<Answer>`를 `Answers`로 대체
-- [ ] `Question`, `Answer`에 글 삭제 메소드 추가
+- [x] `Question`, `Answer`에 글 삭제 메소드 추가
   - [x] 글 삭제 시 로그인 유저와 글쓴이는 동일한지 확인
   - [x] 글 삭제 시 로그인 유저와 글쓴이가 다르면 에러 발생
-  - [ ] 글 삭제의 반환 값은 `List<DeleteHistory>`
+  - [x] 글 삭제의 반환 값은 `List<DeleteHistory>`
 - [x] `Question`을 받아 `DeleteHistory` 생성하는 메소드 추가
 - [x] `Answer`을 받아 `DeleteHistory` 생성하는 메소드 추가

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,9 +1,11 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -50,7 +52,7 @@ public class Answer extends BaseEntity {
     }
 
     public boolean isOwner(User writer) {
-        return this.writer.getId().equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
@@ -61,6 +63,18 @@ public class Answer extends BaseEntity {
             question.addAnswer(this);
         }
         this.question = question;
+    }
+
+    public List<DeleteHistory> delete(User user) throws CannotDeleteException {
+        validateDelete(user);
+        this.deleted = true;
+        return null;
+    }
+
+    private void validateDelete(User user) throws CannotDeleteException {
+        if (!isOwner(user)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
     }
 
     public Long getId() {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -5,7 +5,6 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -65,10 +64,10 @@ public class Answer extends BaseEntity {
         this.question = question;
     }
 
-    public List<DeleteHistory> delete(User user) throws CannotDeleteException {
+    public DeleteHistory delete(User user) throws CannotDeleteException {
         validateDelete(user);
         this.deleted = true;
-        return null;
+        return DeleteHistory.from(this);
     }
 
     private void validateDelete(User user) throws CannotDeleteException {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -67,7 +67,7 @@ public class Answer extends BaseEntity {
     public DeleteHistory delete(User user) throws CannotDeleteException {
         validateDelete(user);
         this.deleted = true;
-        return DeleteHistory.from(this);
+        return DeleteHistory.of(ContentType.ANSWER, this.getId(), this.getWriter());
     }
 
     private void validateDelete(User user) throws CannotDeleteException {

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -21,18 +21,20 @@ public class Answers {
         this.answers.add(answer);
     }
 
-    public void delete(User user) throws CannotDeleteException {
+    public List<DeleteHistory> delete(User user) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
         try {
             for (Answer answer : answers) {
-                answer.delete(user);
+                deleteHistories.add(answer.delete(user));
             }
         } catch (CannotDeleteException e) {
-            restoreDelete();
+            resetDelete();
             throw new CannotDeleteException(e.getMessage());
         }
+        return deleteHistories;
     }
 
-    private void restoreDelete() {
+    private void resetDelete() {
         for (Answer answer : answers) {
             answer.setDeleted(false);
         }

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,34 @@
+package qna.domain;
+
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+public class Answers {
+
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    private List<Answer> answers = new ArrayList<>();
+
+    protected Answers() {
+    }
+
+    public void addAnswer(Answer answer) {
+        this.answers.add(answer);
+    }
+
+    public boolean contains(Answer answer) {
+        return this.answers.contains(answer);
+    }
+
+    public void remove(Answer answer) {
+        this.answers.remove(answer);
+    }
+
+    public int size() {
+        return this.answers.size();
+    }
+
+}

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -23,21 +23,10 @@ public class Answers {
 
     public List<DeleteHistory> delete(User user) throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        try {
-            for (Answer answer : answers) {
-                deleteHistories.add(answer.delete(user));
-            }
-        } catch (CannotDeleteException e) {
-            resetDelete();
-            throw new CannotDeleteException(e.getMessage());
+        for (Answer answer : answers) {
+            deleteHistories.add(answer.delete(user));
         }
         return deleteHistories;
-    }
-
-    private void resetDelete() {
-        for (Answer answer : answers) {
-            answer.setDeleted(false);
-        }
     }
 
     public boolean contains(Answer answer) {

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -17,7 +17,7 @@ public class Answers {
     protected Answers() {
     }
 
-    public void addAnswer(Answer answer) {
+    public void add(Answer answer) {
         this.answers.add(answer);
     }
 

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,5 +1,7 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
+
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
@@ -17,6 +19,23 @@ public class Answers {
 
     public void addAnswer(Answer answer) {
         this.answers.add(answer);
+    }
+
+    public void delete(User user) throws CannotDeleteException {
+        try {
+            for (Answer answer : answers) {
+                answer.delete(user);
+            }
+        } catch (CannotDeleteException e) {
+            restoreDelete();
+            throw new CannotDeleteException(e.getMessage());
+        }
+    }
+
+    private void restoreDelete() {
+        for (Answer answer : answers) {
+            answer.setDeleted(false);
+        }
     }
 
     public boolean contains(Answer answer) {

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -30,12 +30,8 @@ public class DeleteHistory {
         this.createDate = createDate;
     }
 
-    public static DeleteHistory from(Question question) {
-        return new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now());
-    }
-
-    public static DeleteHistory from(Answer answer) {
-        return new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
+    public static DeleteHistory of(ContentType contentType, Long contentId, User deletedBy) {
+        return new DeleteHistory(contentType, contentId, deletedBy, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -30,6 +30,14 @@ public class DeleteHistory {
         this.createDate = createDate;
     }
 
+    public static DeleteHistory from(Question question) {
+        return new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now());
+    }
+
+    public static DeleteHistory from(Answer answer) {
+        return new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -3,6 +3,7 @@ package qna.domain;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -59,9 +60,11 @@ public class Question extends BaseEntity {
 
     public List<DeleteHistory> delete(User user) throws CannotDeleteException {
         validateDelete(user);
-        answersDelete(user);
 
-        return null;
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.addAll(answersDelete(user));
+        deleteHistories.add(questionDelete());
+        return deleteHistories;
     }
 
     private void validateDelete(User user) throws CannotDeleteException {
@@ -70,10 +73,14 @@ public class Question extends BaseEntity {
         }
     }
 
-    private void answersDelete(User user) throws CannotDeleteException {
-        this.answers.delete(user);
+    private DeleteHistory questionDelete() {
+        this.deleted = true;
+        return DeleteHistory.from(this);
     }
 
+    private List<DeleteHistory> answersDelete(User user) throws CannotDeleteException {
+        return this.answers.delete(user);
+    }
 
     public Long getId() {
         return id;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,7 +1,6 @@
 package qna.domain;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -22,8 +21,8 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "writer_id", foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
 
-    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
-    private List<Answer> answers = new ArrayList<>();
+    @Embedded
+    private Answers answers = new Answers();
 
     private boolean deleted = false;
 
@@ -50,7 +49,7 @@ public class Question extends BaseEntity {
     }
 
     public void addAnswer(Answer answer) {
-        this.answers.add(answer);
+        this.answers.addAnswer(answer);
         if (answer.getQuestion() != this) {
             answer.toQuestion(this);
         }
@@ -84,7 +83,7 @@ public class Question extends BaseEntity {
         this.writer = writer;
     }
 
-    public List<Answer> getAnswers() {
+    public Answers getAnswers() {
         return answers;
     }
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,5 +1,7 @@
 package qna.domain;
 
+import qna.CannotDeleteException;
+
 import javax.persistence.*;
 import java.util.List;
 
@@ -45,7 +47,7 @@ public class Question extends BaseEntity {
     }
 
     public boolean isOwner(User writer) {
-        return this.writer.getId().equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -54,6 +56,24 @@ public class Question extends BaseEntity {
             answer.toQuestion(this);
         }
     }
+
+    public List<DeleteHistory> delete(User user) throws CannotDeleteException {
+        validateDelete(user);
+        answersDelete(user);
+
+        return null;
+    }
+
+    private void validateDelete(User user) throws CannotDeleteException {
+        if (!isOwner(user)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+    }
+
+    private void answersDelete(User user) throws CannotDeleteException {
+        this.answers.delete(user);
+    }
+
 
     public Long getId() {
         return id;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -51,7 +51,7 @@ public class Question extends BaseEntity {
     }
 
     public void addAnswer(Answer answer) {
-        this.answers.addAnswer(answer);
+        this.answers.add(answer);
         if (answer.getQuestion() != this) {
             answer.toQuestion(this);
         }
@@ -73,7 +73,7 @@ public class Question extends BaseEntity {
 
     private DeleteHistory questionDelete() {
         this.deleted = true;
-        return DeleteHistory.from(this);
+        return DeleteHistory.of(ContentType.QUESTION, this.getId(), this.writer);
     }
 
     private List<DeleteHistory> answersDelete(User user) throws CannotDeleteException {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -3,7 +3,6 @@ package qna.domain;
 import qna.CannotDeleteException;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -61,9 +60,8 @@ public class Question extends BaseEntity {
     public List<DeleteHistory> delete(User user) throws CannotDeleteException {
         validateDelete(user);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.addAll(answersDelete(user));
-        deleteHistories.add(questionDelete());
+        List<DeleteHistory> deleteHistories = answersDelete(user);
+        deleteHistories.add(0, questionDelete());
         return deleteHistories;
     }
 

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -6,23 +6,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
 
 @Service
 public class QnaService {
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
     private QuestionRepository questionRepository;
-    private AnswerRepository answerRepository;
     private DeleteHistoryService deleteHistoryService;
 
-    public QnaService(QuestionRepository questionRepository, AnswerRepository answerRepository, DeleteHistoryService deleteHistoryService) {
+    public QnaService(QuestionRepository questionRepository, DeleteHistoryService deleteHistoryService) {
         this.questionRepository = questionRepository;
-        this.answerRepository = answerRepository;
         this.deleteHistoryService = deleteHistoryService;
     }
 
@@ -35,24 +31,6 @@ public class QnaService {
     @Transactional
     public void deleteQuestion(User loginUser, Long questionId) throws CannotDeleteException {
         Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(questionId);
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(question.delete(loginUser));
     }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -47,7 +47,7 @@ public class AnswerTest {
     }
 
     @Test
-    @DisplayName("글쓴이와 답변자가 같은 경우 삭제 가능")
+    @DisplayName("글쓴이와 답변자가 같은 경우 삭제 가능하며 DeleteHistory 반환")
     void delete_success() throws CannotDeleteException {
         //given
         User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
@@ -55,7 +55,7 @@ public class AnswerTest {
         Answer answer = new Answer(writer, question, "Answers Contents");
 
         //except
-        answer.delete(writer);
+        assertThat(answer.delete(writer)).isInstanceOf(DeleteHistory.class);
     }
 
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -25,8 +25,8 @@ public class AnswerTest {
 
         //then
         assertAll(
-                () -> assertThat(question.getAnswers()).hasSize(1),
-                () -> assertThat(question.getAnswers().get(0)).isSameAs(answer),
+                () -> assertThat(question.getAnswers().size()).isEqualTo(1),
+                () -> assertThat(question.getAnswers().contains(answer)).isTrue(),
                 () -> assertThat(answer.getQuestion()).isSameAs(question)
         );
     }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -2,8 +2,10 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AnswerTest {
@@ -29,6 +31,31 @@ public class AnswerTest {
                 () -> assertThat(question.getAnswers().contains(answer)).isTrue(),
                 () -> assertThat(answer.getQuestion()).isSameAs(question)
         );
+    }
+
+    @Test
+    @DisplayName("글쓴이와 답변자가 다른 경우 삭제 에러")
+    void delete_error() {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        User other = new User(2L, "coco", "password", "coco", "coco@slipp.net");
+        Question question = new Question("title1", "contents1").writeBy(writer);
+        Answer answer = new Answer(writer, question, "Answers Contents");
+
+        //except
+        assertThatThrownBy(()-> answer.delete(other)).isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    @DisplayName("글쓴이와 답변자가 같은 경우 삭제 가능")
+    void delete_success() throws CannotDeleteException {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question("title1", "contents1").writeBy(writer);
+        Answer answer = new Answer(writer, question, "Answers Contents");
+
+        //except
+        answer.delete(writer);
     }
 
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -11,7 +11,7 @@ public class AnswerTest {
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
 
     @Test
-    @DisplayName("toQuestion은 question의 answers와 연관 관계 편의 메소드이다.")
+    @DisplayName("답변에 질문 연결")
     void toQuestion() {
         //given
         User writer = new User(null, "sangjae", "password", "name", "javajigi@slipp.net");

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,20 @@
+package qna.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnswersTest {
+
+    @Test
+    @DisplayName("Answers 생성")
+    void create() {
+        //given
+        Answers answers = new Answers();
+
+        //expect
+        assertThat(answers).isNotNull();
+    }
+
+}

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,11 +1,24 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnswersTest {
+
+    private Answer answer;
+
+    @BeforeEach
+    void createAnswer() {
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(1L, "title1", "contents1").writeBy(writer);
+        answer = new Answer(1L, writer, question, "Answers Contents");
+    }
 
     @Test
     @DisplayName("Answers 생성")
@@ -17,4 +30,59 @@ public class AnswersTest {
         assertThat(answers).isNotNull();
     }
 
+    @Test
+    @DisplayName("Answers에 Answer를 1개를 추가하면 size는 1이다")
+    void addAndSize() {
+        //given
+        Answers answers = new Answers();
+
+        //when
+        answers.add(answer);
+
+        //then
+        assertThat(answers.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Answers에 이미 같은 Answer가 들어있으면 contains는 true이다")
+    void contains_true() {
+        //given
+        Answers answers = new Answers();
+        answers.add(answer);
+
+        //expect
+        assertThat(answers.contains(answer)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Answers에 같은 Answer가 들어있지 않다면 contains는 false이다")
+    void contains_false() {
+        //given
+        Answers answers = new Answers();
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(1L, "title1", "contents1").writeBy(writer);
+        Answer diff = new Answer(1L, writer, question, "Answers Contents");
+        answers.add(diff);
+
+        //expect
+        assertThat(answers.contains(answer)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Answers에 모두 같은 작성자의 Answer가 들어있다면 삭제할 수 있고 List<DeleteHistory> 반환 한다")
+    void delete_성공() throws CannotDeleteException {
+        //given
+        Answers answers = new Answers();
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(1L, "title1", "contents1").writeBy(writer);
+        for (long i = 1; i <= 5; i++) {
+            answers.add(new Answer(i, writer, question, "Answers Contents"));
+        }
+
+        //when
+        List<DeleteHistory> deleteHistories = answers.delete(writer);
+
+        //then
+        assertThat(deleteHistories).hasSize(5);
+    }
 }

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -27,7 +27,7 @@ class DeleteHistoryTest {
         Question question = new Question("title1", "contents1");
 
         //expect
-        assertThat(DeleteHistory.from(question)).isNotNull();
+        assertThat(DeleteHistory.of(ContentType.QUESTION, question.getId(), question.getWriter())).isNotNull();
     }
 
     @Test
@@ -39,6 +39,6 @@ class DeleteHistoryTest {
         Answer answer = new Answer(1L, writer, question, "Answers Contents");
 
         //expect
-        assertThat(DeleteHistory.from(answer)).isNotNull();
+        assertThat(DeleteHistory.of(ContentType.ANSWER, answer.getId(), answer.getWriter())).isNotNull();
     }
 }

--- a/src/test/java/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryTest.java
@@ -19,4 +19,26 @@ class DeleteHistoryTest {
         //expect
         assertThat(deleteHistory).isNotNull();
     }
+
+    @Test
+    @DisplayName("Question을 받아 DeleteHistory를 생성")
+    void 정적_팩토리_메소드_Question() {
+        //given
+        Question question = new Question("title1", "contents1");
+
+        //expect
+        assertThat(DeleteHistory.from(question)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Answer를 받아 DeleteHistory를 생성")
+    void 정적_팩토리_메소드_Answer() {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question("title1", "contents1").writeBy(writer);
+        Answer answer = new Answer(1L, writer, question, "Answers Contents");
+
+        //expect
+        assertThat(DeleteHistory.from(answer)).isNotNull();
+    }
 }

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -62,7 +62,7 @@ class QuestionRepositoryTest {
         Optional<Question> optionalQuestion = questionRepository.findById(question.getId());
 
         //then
-        assertThat(optionalQuestion.get().getAnswers()).hasSize(1);
+        assertThat(optionalQuestion.get().getAnswers().size()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -35,8 +35,8 @@ public class QuestionTest {
         //then
         assertAll(
                 () -> assertThat(answer.getQuestion()).isSameAs(question),
-                () -> assertThat(question.getAnswers()).hasSize(1),
-                () -> assertThat(question.getAnswers().get(0)).isSameAs(answer)
+                () -> assertThat(question.getAnswers().size()).isEqualTo(1),
+                () -> assertThat(question.getAnswers().contains(answer)).isTrue()
         );
     }
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -52,6 +52,40 @@ public class QuestionTest {
 
         //except
         assertThatThrownBy(()-> question.delete(other)).isInstanceOf(CannotDeleteException.class);
+    }
 
+    @Test
+    @DisplayName("글쓴이와 질문자가 같은 경우 삭제 가능")
+    void delete_success() throws CannotDeleteException {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(1L,"title1", "contents1").writeBy(writer);
+
+        //except
+        assertThat(question.delete(writer)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("질문 삭제 성공 시 답변이 없으면 반환 DeleteHistory 리스트 size는 1개이다")
+    void delete_success_답변_없음() throws CannotDeleteException {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(1L,"title1", "contents1").writeBy(writer);
+
+        //except
+        assertThat(question.delete(writer)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("질문 삭제 성공 시 답변이 2개 있으면 반환 DeleteHistory 리스트 size는 3개이다")
+    void delete_success_답변_2개() throws CannotDeleteException {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        Question question = new Question(99L,"title1", "contents1").writeBy(writer);
+        question.addAnswer(new Answer(10L,writer, question, "Answers Contents"));
+        question.addAnswer(new Answer(11L,writer, question, "Answers Contents"));
+
+        //except
+        assertThat(question.delete(writer)).hasSize(3);
     }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -22,7 +22,7 @@ public class QuestionTest {
     }
 
     @Test
-    @DisplayName("addAnswer은 Answer의 question과 연관 관계 편의 메소드이다.")
+    @DisplayName("질문에 답변 추가")
     void addAnswer() {
         //given
         User writer = new User(null, "sangjae", "password", "name", "javajigi@slipp.net");

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -2,8 +2,10 @@ package qna.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import qna.CannotDeleteException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class QuestionTest {
@@ -40,4 +42,16 @@ public class QuestionTest {
         );
     }
 
+    @Test
+    @DisplayName("글쓴이와 질문자가 다른 경우 삭제 에러")
+    void delete() {
+        //given
+        User writer = new User(1L, "sangjae", "password", "name", "javajigi@slipp.net");
+        User other = new User(2L, "coco", "password", "coco", "coco@slipp.net");
+        Question question = new Question("title1", "contents1").writeBy(writer);
+
+        //except
+        assertThatThrownBy(()-> question.delete(other)).isInstanceOf(CannotDeleteException.class);
+
+    }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -25,9 +25,6 @@ class QnaServiceTest {
     private QuestionRepository questionRepository;
 
     @Mock
-    private AnswerRepository answerRepository;
-
-    @Mock
     private DeleteHistoryService deleteHistoryService;
 
     @InjectMocks
@@ -46,7 +43,6 @@ class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
@@ -66,7 +62,6 @@ class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
 
@@ -81,7 +76,6 @@ class QnaServiceTest {
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
         assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);


### PR DESCRIPTION
안녕하세요 😀

JPA 3단계 질문 삭제하기 리팩터링 PR요청드립니다.

질문 드릴게 하나 있는데 `isOwner()` 메소드를 보면  `user.getId().equals(user.getId())`에서 `user.equals(user)`
이런식으로 바꾸고 User 클래스의 equals도 id로만 비교하게 만들었습니다.

엔티티는 테이블과 매핑한다는 관점에서는 `id`만 일치하면 같다라 생각해서 `id`비교로만 `equals()`를 구현했지만,
엔티티 + 도메인으로 봤을 때는 '다른 값도 비교를 해야하지 않을까?' 라고도 생각이 드는데...

혹시 어떻게 생각하는지 알고싶습니다!

감사합니다 :)